### PR TITLE
(Issue 217) Advanced CSS support.

### DIFF
--- a/canvg.js
+++ b/canvg.js
@@ -1,6 +1,6 @@
 /*
  * canvg.js - Javascript SVG parser and renderer on Canvas
- * MIT Licensed 
+ * MIT Licensed
  * Gabe Lerner (gabelerner@gmail.com)
  * http://code.google.com/p/canvg/
  *
@@ -39,17 +39,17 @@
 			}
 			return;
 		}
-	
+
 		if (typeof target == 'string') {
 			target = document.getElementById(target);
 		}
-		
+
 		// store class on canvas
 		if (target.svg != null) target.svg.stop();
 		var svg = build(opts || {});
 		// on i.e. 8 for flash canvas, we can't assign the property so check for it
 		if (!(target.childNodes.length == 1 && target.childNodes[0].nodeName == 'OBJECT')) target.svg = svg;
-		
+
 		var ctx = target.getContext('2d');
 		if (typeof(s.documentElement) != 'undefined') {
 			// load from xml doc
@@ -65,23 +65,85 @@
 		}
 	}
 
+	// see https://developer.mozilla.org/en-US/docs/Web/API/Element.matches
+	var matchesSelector;
+	if (typeof(Element.prototype.matches) != 'undefined') {
+		matchesSelector = function(node, selector) {
+			return node.matches(selector);
+		};
+	} else if (typeof(Element.prototype.webkitMatchesSelector) != 'undefined') {
+		matchesSelector = function(node, selector) {
+			return node.webkitMatchesSelector(selector);
+		};
+	} else if (typeof(Element.prototype.mozMatchesSelector) != 'undefined') {
+		matchesSelector = function(node, selector) {
+			return node.mozMatchesSelector(selector);
+		};
+	} else if (typeof(Element.prototype.msMatchesSelector) != 'undefined') {
+		matchesSelector = function(node, selector) {
+			return node.msMatchesSelector(selector);
+		};
+	} else if (typeof(Element.prototype.oMatchesSelector) != 'undefined') {
+		matchesSelector = function(node, selector) {
+			return node.oMatchesSelector(selector);
+		};
+	} else {
+		// requires Sizzle: https://github.com/jquery/sizzle/wiki/Sizzle-Documentation
+		// without Sizzle, this is a ReferenceError
+		matchesSelector = Sizzle.matchesSelector;
+	}
+
+	// slightly modified version of https://github.com/keeganstreet/specificity/blob/master/specificity.js
+	var attributeRegex = /(\[[^\]]+\])/g;
+	var idRegex = /(#[^\s\+>~\.\[:]+)/g;
+	var classRegex = /(\.[^\s\+>~\.\[:]+)/g;
+	var pseudoElementRegex = /(::[^\s\+>~\.\[:]+|:first-line|:first-letter|:before|:after)/gi;
+	var pseudoClassWithBracketsRegex = /(:[\w-]+\([^\)]*\))/gi;
+	var pseudoClassRegex = /(:[^\s\+>~\.\[:]+)/g;
+	var elementRegex = /([^\s\+>~\.\[:]+)/g;
+	function getSelectorSpecificity(selector) {
+		var typeCount = [0, 0, 0];
+		var findMatch = function(regex, type) {
+			var matches = selector.match(regex);
+			if (matches == null) {
+				return;
+			}
+			typeCount[type] += matches.length;
+			selector = selector.replace(regex, ' ');
+		};
+
+		selector = selector.replace(/:not\(([^\)]*)\)/g, '     $1 ');
+		selector = selector.replace(/{[^]*/gm, ' ');
+		findMatch(attributeRegex, 1);
+		findMatch(idRegex, 0);
+		findMatch(classRegex, 1);
+		findMatch(pseudoElementRegex, 2);
+		findMatch(pseudoClassWithBracketsRegex, 1);
+		findMatch(pseudoClassRegex, 1);
+		selector = selector.replace(/[\*\s\+>~]/g, ' ');
+		selector = selector.replace(/[#\.]/g, ' ');
+		findMatch(elementRegex, 2);
+		return typeCount.join('');
+	}
+
 	function build(opts) {
 		var svg = { opts: opts };
-		
+
 		svg.FRAMERATE = 30;
 		svg.MAX_VIRTUAL_PIXELS = 30000;
-		
+
 		svg.log = function(msg) {};
 		if (svg.opts['log'] == true && typeof(console) != 'undefined') {
 			svg.log = function(msg) { console.log(msg); };
 		};
-		
+
 		// globals
 		svg.init = function(ctx) {
 			var uniqueId = 0;
 			svg.UniqueId = function () { uniqueId++; return 'canvg' + uniqueId;	};
 			svg.Definitions = {};
 			svg.Styles = {};
+			svg.StylesSpecificity = {};
 			svg.Animations = [];
 			svg.Images = [];
 			svg.ctx = ctx;
@@ -97,14 +159,14 @@
 					if (d != null && typeof(d) == 'number') return d;
 					if (d == 'x') return this.width();
 					if (d == 'y') return this.height();
-					return Math.sqrt(Math.pow(this.width(), 2) + Math.pow(this.height(), 2)) / Math.sqrt(2);			
+					return Math.sqrt(Math.pow(this.width(), 2) + Math.pow(this.height(), 2)) / Math.sqrt(2);
 				}
 			});
 		}
 		svg.init();
-		
+
 		// images loaded
-		svg.ImagesLoaded = function() { 
+		svg.ImagesLoaded = function() {
 			for (var i=0; i<svg.Images.length; i++) {
 				if (!svg.Images[i].loaded) return false;
 			}
@@ -113,10 +175,10 @@
 
 		// trim
 		svg.trim = function(s) { return s.replace(/^\s+|\s+$/g, ''); }
-		
+
 		// compress spaces
 		svg.compressSpaces = function(s) { return s.replace(/[\s\r\t\n]+/gm,' '); }
-		
+
 		// ajax
 		svg.ajax = function(url) {
 			var AJAX;
@@ -128,8 +190,8 @@
 			   return AJAX.responseText;
 			}
 			return null;
-		} 
-		
+		}
+
 		// parse xml
 		svg.parseXml = function(xml) {
 			if (typeof(Windows) != 'undefined' && typeof(Windows.Data) != 'undefined' && typeof(Windows.Data.Xml) != 'undefined') {
@@ -144,49 +206,49 @@
 				var parser = new DOMParser();
 				return parser.parseFromString(xml, 'text/xml');
 			}
-			else 
+			else
 			{
 				xml = xml.replace(/<!DOCTYPE svg[^>]*>/, '');
 				var xmlDoc = new ActiveXObject('Microsoft.XMLDOM');
 				xmlDoc.async = 'false';
-				xmlDoc.loadXML(xml); 
+				xmlDoc.loadXML(xml);
 				return xmlDoc;
-			}		
+			}
 		}
-		
+
 		svg.Property = function(name, value) {
 			this.name = name;
 			this.value = value;
-		}	
+		}
 			svg.Property.prototype.getValue = function() {
 				return this.value;
 			}
-		
+
 			svg.Property.prototype.hasValue = function() {
 				return (this.value != null && this.value !== '');
 			}
-							
+
 			// return the numerical value of the property
 			svg.Property.prototype.numValue = function() {
 				if (!this.hasValue()) return 0;
-				
+
 				var n = parseFloat(this.value);
 				if ((this.value + '').match(/%$/)) {
 					n = n / 100.0;
 				}
 				return n;
 			}
-			
+
 			svg.Property.prototype.valueOrDefault = function(def) {
 				if (this.hasValue()) return this.value;
 				return def;
 			}
-			
+
 			svg.Property.prototype.numValueOrDefault = function(def) {
 				if (this.hasValue()) return this.numValue();
 				return def;
 			}
-			
+
 			// color extensions
 				// augment the current color value with the opacity
 				svg.Property.prototype.addOpacity = function(opacityProp) {
@@ -199,7 +261,7 @@
 					}
 					return new svg.Property(this.name, newValue);
 				}
-			
+
 			// definition extensions
 				// get the definition from the definitions table
 				svg.Property.prototype.getDefinition = function() {
@@ -208,19 +270,19 @@
 					if (!name) { name = this.value; }
 					return svg.Definitions[name];
 				}
-				
+
 				svg.Property.prototype.isUrlDefinition = function() {
 					return this.value.indexOf('url(') == 0
 				}
-				
+
 				svg.Property.prototype.getFillStyleDefinition = function(e, opacityProp) {
 					var def = this.getDefinition();
-					
+
 					// gradient
 					if (def != null && def.createGradient) {
 						return def.createGradient(svg.ctx, e, opacityProp);
 					}
-					
+
 					// pattern
 					if (def != null && def.createPattern) {
 						if (def.getHrefAttribute().hasValue()) {
@@ -230,29 +292,29 @@
 						}
 						return def.createPattern(svg.ctx, e);
 					}
-					
+
 					return null;
 				}
-			
+
 			// length extensions
 				svg.Property.prototype.getDPI = function(viewPort) {
 					return 96.0; // TODO: compute?
 				}
-				
+
 				svg.Property.prototype.getEM = function(viewPort) {
 					var em = 12;
-					
+
 					var fontSize = new svg.Property('fontSize', svg.Font.Parse(svg.ctx.font).fontSize);
 					if (fontSize.hasValue()) em = fontSize.toPixels(viewPort);
-					
+
 					return em;
 				}
-				
+
 				svg.Property.prototype.getUnits = function() {
 					var s = this.value+'';
 					return s.replace(/[0-9\.\-]/g,'');
 				}
-			
+
 				// get the length as pixels
 				svg.Property.prototype.toPixels = function(viewPort, processPercent) {
 					if (!this.hasValue()) return 0;
@@ -280,7 +342,7 @@
 					if (s.match(/ms$/)) return this.numValue();
 					return this.numValue();
 				}
-			
+
 			// angle extensions
 				// get the angle as radians
 				svg.Property.prototype.toRadians = function() {
@@ -291,7 +353,7 @@
 					if (s.match(/rad$/)) return this.numValue();
 					return this.numValue() * (Math.PI / 180.0);
 				}
-		
+
 			// text extensions
 				// get the text baseline
 				var textBaselineMapping = {
@@ -311,25 +373,25 @@
 					if (!this.hasValue()) return null;
 					return textBaselineMapping[this.value];
 				}
-				
+
 		// fonts
 		svg.Font = new (function() {
 			this.Styles = 'normal|italic|oblique|inherit';
 			this.Variants = 'normal|small-caps|inherit';
 			this.Weights = 'normal|bold|bolder|lighter|100|200|300|400|500|600|700|800|900|inherit';
-			
+
 			this.CreateFont = function(fontStyle, fontVariant, fontWeight, fontSize, fontFamily, inherit) {
 				var f = inherit != null ? this.Parse(inherit) : this.CreateFont('', '', '', '', '', svg.ctx.font);
-				return { 
-					fontFamily: fontFamily || f.fontFamily, 
-					fontSize: fontSize || f.fontSize, 
-					fontStyle: fontStyle || f.fontStyle, 
-					fontWeight: fontWeight || f.fontWeight, 
+				return {
+					fontFamily: fontFamily || f.fontFamily,
+					fontSize: fontSize || f.fontSize,
+					fontStyle: fontStyle || f.fontStyle,
+					fontWeight: fontWeight || f.fontWeight,
 					fontVariant: fontVariant || f.fontVariant,
-					toString: function () { return [this.fontStyle, this.fontVariant, this.fontWeight, this.fontSize, this.fontFamily].join(' ') } 
-				} 
+					toString: function () { return [this.fontStyle, this.fontVariant, this.fontWeight, this.fontSize, this.fontFamily].join(' ') }
+				}
 			}
-			
+
 			var that = this;
 			this.Parse = function(s) {
 				var f = {};
@@ -346,7 +408,7 @@
 				return f;
 			}
 		});
-		
+
 		// points and paths
 		svg.ToNumberArray = function(s) {
 			var a = svg.trim(svg.compressSpaces((s || '').replace(/,/g, ' '))).split(' ');
@@ -354,15 +416,15 @@
 				a[i] = parseFloat(a[i]);
 			}
 			return a;
-		}		
+		}
 		svg.Point = function(x, y) {
 			this.x = x;
 			this.y = y;
-		}	
+		}
 			svg.Point.prototype.angleTo = function(p) {
 				return Math.atan2(p.y - this.y, p.x - this.x);
 			}
-			
+
 			svg.Point.prototype.applyTransform = function(v) {
 				var xp = this.x * v[0] + this.y * v[2] + v[4];
 				var yp = this.x * v[1] + this.y * v[3] + v[5];
@@ -382,20 +444,20 @@
 			}
 			return path;
 		}
-		
+
 		// bounding box
 		svg.BoundingBox = function(x1, y1, x2, y2) { // pass in initial points if you want
 			this.x1 = Number.NaN;
 			this.y1 = Number.NaN;
 			this.x2 = Number.NaN;
 			this.y2 = Number.NaN;
-			
+
 			this.x = function() { return this.x1; }
 			this.y = function() { return this.y1; }
 			this.width = function() { return this.x2 - this.x1; }
 			this.height = function() { return this.y2 - this.y1; }
-			
-			this.addPoint = function(x, y) {	
+
+			this.addPoint = function(x, y) {
 				if (x != null) {
 					if (isNaN(this.x1) || isNaN(this.x2)) {
 						this.x1 = x;
@@ -404,7 +466,7 @@
 					if (x < this.x1) this.x1 = x;
 					if (x > this.x2) this.x2 = x;
 				}
-			
+
 				if (y != null) {
 					if (isNaN(this.y1) || isNaN(this.y2)) {
 						this.y1 = y;
@@ -413,15 +475,15 @@
 					if (y < this.y1) this.y1 = y;
 					if (y > this.y2) this.y2 = y;
 				}
-			}			
+			}
 			this.addX = function(x) { this.addPoint(x, null); }
 			this.addY = function(y) { this.addPoint(null, y); }
-			
+
 			this.addBoundingBox = function(bb) {
 				this.addPoint(bb.x1, bb.y1);
 				this.addPoint(bb.x2, bb.y2);
 			}
-			
+
 			this.addQuadraticCurve = function(p0x, p0y, p1x, p1y, p2x, p2y) {
 				var cp1x = p0x + 2/3 * (p1x - p0x); // CP1 = QP0 + 2/3 *(QP1-QP0)
 				var cp1y = p0y + 2/3 * (p1y - p0y); // CP1 = QP0 + 2/3 *(QP1-QP0)
@@ -429,25 +491,25 @@
 				var cp2y = cp1y + 1/3 * (p2y - p0y); // CP2 = CP1 + 1/3 *(QP2-QP0)
 				this.addBezierCurve(p0x, p0y, cp1x, cp2x, cp1y,	cp2y, p2x, p2y);
 			}
-			
+
 			this.addBezierCurve = function(p0x, p0y, p1x, p1y, p2x, p2y, p3x, p3y) {
 				// from http://blog.hackers-cafe.net/2009/06/how-to-calculate-bezier-curves-bounding.html
 				var p0 = [p0x, p0y], p1 = [p1x, p1y], p2 = [p2x, p2y], p3 = [p3x, p3y];
 				this.addPoint(p0[0], p0[1]);
 				this.addPoint(p3[0], p3[1]);
-				
+
 				for (i=0; i<=1; i++) {
-					var f = function(t) { 
+					var f = function(t) {
 						return Math.pow(1-t, 3) * p0[i]
 						+ 3 * Math.pow(1-t, 2) * t * p1[i]
 						+ 3 * (1-t) * Math.pow(t, 2) * p2[i]
 						+ Math.pow(t, 3) * p3[i];
 					}
-					
+
 					var b = 6 * p0[i] - 12 * p1[i] + 6 * p2[i];
 					var a = -3 * p0[i] + 9 * p1[i] - 9 * p2[i] + 3 * p3[i];
 					var c = 3 * p1[i] - 3 * p0[i];
-					
+
 					if (a == 0) {
 						if (b == 0) continue;
 						var t = -c / b;
@@ -457,7 +519,7 @@
 						}
 						continue;
 					}
-					
+
 					var b2ac = Math.pow(b, 2) - 4 * c * a;
 					if (b2ac < 0) continue;
 					var t1 = (-b + Math.sqrt(b2ac)) / (2 * a);
@@ -472,23 +534,23 @@
 					}
 				}
 			}
-			
+
 			this.isPointInBox = function(x, y) {
 				return (this.x1 <= x && x <= this.x2 && this.y1 <= y && y <= this.y2);
 			}
-			
+
 			this.addPoint(x1, y1);
 			this.addPoint(x2, y2);
 		}
-		
+
 		// transforms
-		svg.Transform = function(v) {	
+		svg.Transform = function(v) {
 			var that = this;
 			this.Type = {}
-		
+
 			// translate
 			this.Type.translate = function(s) {
-				this.p = svg.CreatePoint(s);			
+				this.p = svg.CreatePoint(s);
 				this.apply = function(ctx) {
 					ctx.translate(this.p.x || 0.0, this.p.y || 0.0);
 				}
@@ -499,7 +561,7 @@
 					p.applyTransform([1, 0, 0, 1, this.p.x || 0.0, this.p.y || 0.0]);
 				}
 			}
-			
+
 			// rotate
 			this.Type.rotate = function(s) {
 				var a = svg.ToNumberArray(s);
@@ -521,9 +583,9 @@
 					p.applyTransform([1, 0, 0, 1, this.p.x || 0.0, this.p.y || 0.0]);
 					p.applyTransform([Math.cos(a), Math.sin(a), -Math.sin(a), Math.cos(a), 0, 0]);
 					p.applyTransform([1, 0, 0, 1, -this.p.x || 0.0, -this.p.y || 0.0]);
-				}			
+				}
 			}
-			
+
 			this.Type.scale = function(s) {
 				this.p = svg.CreatePoint(s);
 				this.apply = function(ctx) {
@@ -534,9 +596,9 @@
 				}
 				this.applyToPoint = function(p) {
 					p.applyTransform([this.p.x || 0.0, 0, 0, this.p.y || 0.0, 0, 0]);
-				}				
+				}
 			}
-			
+
 			this.Type.matrix = function(s) {
 				this.m = svg.ToNumberArray(s);
 				this.apply = function(ctx) {
@@ -564,50 +626,50 @@
 				}
 				this.applyToPoint = function(p) {
 					p.applyTransform(this.m);
-				}					
+				}
 			}
-			
+
 			this.Type.SkewBase = function(s) {
 				this.base = that.Type.matrix;
 				this.base(s);
 				this.angle = new svg.Property('angle', s);
 			}
 			this.Type.SkewBase.prototype = new this.Type.matrix;
-			
+
 			this.Type.skewX = function(s) {
 				this.base = that.Type.SkewBase;
 				this.base(s);
 				this.m = [1, 0, Math.tan(this.angle.toRadians()), 1, 0, 0];
 			}
 			this.Type.skewX.prototype = new this.Type.SkewBase;
-			
+
 			this.Type.skewY = function(s) {
 				this.base = that.Type.SkewBase;
 				this.base(s);
 				this.m = [1, Math.tan(this.angle.toRadians()), 0, 1, 0, 0];
 			}
 			this.Type.skewY.prototype = new this.Type.SkewBase;
-		
+
 			this.transforms = [];
-			
+
 			this.apply = function(ctx) {
 				for (var i=0; i<this.transforms.length; i++) {
 					this.transforms[i].apply(ctx);
 				}
 			}
-			
+
 			this.unapply = function(ctx) {
 				for (var i=this.transforms.length-1; i>=0; i--) {
 					this.transforms[i].unapply(ctx);
 				}
 			}
-			
+
 			this.applyToPoint = function(p) {
 				for (var i=0; i<this.transforms.length; i++) {
 					this.transforms[i].applyToPoint(p);
 				}
 			}
-			
+
 			var data = svg.trim(svg.compressSpaces(v)).replace(/\)([a-zA-Z])/g, ') $1').replace(/\)(\s?,\s?)/g,') ').split(/\s(?=[a-z])/);
 			for (var i=0; i<data.length; i++) {
 				var type = svg.trim(data[i].split('(')[0]);
@@ -617,84 +679,85 @@
 				this.transforms.push(transform);
 			}
 		}
-		
+
 		// aspect ratio
 		svg.AspectRatio = function(ctx, aspectRatio, width, desiredWidth, height, desiredHeight, minX, minY, refX, refY) {
 			// aspect ratio - http://www.w3.org/TR/SVG/coords.html#PreserveAspectRatioAttribute
 			aspectRatio = svg.compressSpaces(aspectRatio);
 			aspectRatio = aspectRatio.replace(/^defer\s/,''); // ignore defer
 			var align = aspectRatio.split(' ')[0] || 'xMidYMid';
-			var meetOrSlice = aspectRatio.split(' ')[1] || 'meet';					
-	
+			var meetOrSlice = aspectRatio.split(' ')[1] || 'meet';
+
 			// calculate scale
 			var scaleX = width / desiredWidth;
 			var scaleY = height / desiredHeight;
 			var scaleMin = Math.min(scaleX, scaleY);
 			var scaleMax = Math.max(scaleX, scaleY);
 			if (meetOrSlice == 'meet') { desiredWidth *= scaleMin; desiredHeight *= scaleMin; }
-			if (meetOrSlice == 'slice') { desiredWidth *= scaleMax; desiredHeight *= scaleMax; }	
-			
+			if (meetOrSlice == 'slice') { desiredWidth *= scaleMax; desiredHeight *= scaleMax; }
+
 			refX = new svg.Property('refX', refX);
 			refY = new svg.Property('refY', refY);
-			if (refX.hasValue() && refY.hasValue()) {				
+			if (refX.hasValue() && refY.hasValue()) {
 				ctx.translate(-scaleMin * refX.toPixels('x'), -scaleMin * refY.toPixels('y'));
-			} 
-			else {					
-				// align
-				if (align.match(/^xMid/) && ((meetOrSlice == 'meet' && scaleMin == scaleY) || (meetOrSlice == 'slice' && scaleMax == scaleY))) ctx.translate(width / 2.0 - desiredWidth / 2.0, 0); 
-				if (align.match(/YMid$/) && ((meetOrSlice == 'meet' && scaleMin == scaleX) || (meetOrSlice == 'slice' && scaleMax == scaleX))) ctx.translate(0, height / 2.0 - desiredHeight / 2.0); 
-				if (align.match(/^xMax/) && ((meetOrSlice == 'meet' && scaleMin == scaleY) || (meetOrSlice == 'slice' && scaleMax == scaleY))) ctx.translate(width - desiredWidth, 0); 
-				if (align.match(/YMax$/) && ((meetOrSlice == 'meet' && scaleMin == scaleX) || (meetOrSlice == 'slice' && scaleMax == scaleX))) ctx.translate(0, height - desiredHeight); 
 			}
-			
+			else {
+				// align
+				if (align.match(/^xMid/) && ((meetOrSlice == 'meet' && scaleMin == scaleY) || (meetOrSlice == 'slice' && scaleMax == scaleY))) ctx.translate(width / 2.0 - desiredWidth / 2.0, 0);
+				if (align.match(/YMid$/) && ((meetOrSlice == 'meet' && scaleMin == scaleX) || (meetOrSlice == 'slice' && scaleMax == scaleX))) ctx.translate(0, height / 2.0 - desiredHeight / 2.0);
+				if (align.match(/^xMax/) && ((meetOrSlice == 'meet' && scaleMin == scaleY) || (meetOrSlice == 'slice' && scaleMax == scaleY))) ctx.translate(width - desiredWidth, 0);
+				if (align.match(/YMax$/) && ((meetOrSlice == 'meet' && scaleMin == scaleX) || (meetOrSlice == 'slice' && scaleMax == scaleX))) ctx.translate(0, height - desiredHeight);
+			}
+
 			// scale
 			if (align == 'none') ctx.scale(scaleX, scaleY);
-			else if (meetOrSlice == 'meet') ctx.scale(scaleMin, scaleMin); 
-			else if (meetOrSlice == 'slice') ctx.scale(scaleMax, scaleMax); 	
-			
+			else if (meetOrSlice == 'meet') ctx.scale(scaleMin, scaleMin);
+			else if (meetOrSlice == 'slice') ctx.scale(scaleMax, scaleMax);
+
 			// translate
-			ctx.translate(minX == null ? 0 : -minX, minY == null ? 0 : -minY);			
+			ctx.translate(minX == null ? 0 : -minX, minY == null ? 0 : -minY);
 		}
-		
+
 		// elements
 		svg.Element = {}
-		
+
 		svg.EmptyProperty = new svg.Property('EMPTY', '');
-		
-		svg.Element.ElementBase = function(node) {	
+
+		svg.Element.ElementBase = function(node) {
 			this.attributes = {};
 			this.styles = {};
+			this.stylesSpecificity = {};
 			this.children = [];
-			
+
 			// get or create attribute
 			this.attribute = function(name, createIfNotExists) {
 				var a = this.attributes[name];
 				if (a != null) return a;
-							
+
 				if (createIfNotExists == true) { a = new svg.Property(name, ''); this.attributes[name] = a; }
 				return a || svg.EmptyProperty;
 			}
-			
+
 			this.getHrefAttribute = function() {
-				for (var a in this.attributes) { 
-					if (a.match(/:href$/)) { 
-						return this.attributes[a]; 
-					} 
+				for (var a in this.attributes) {
+					if (a.match(/:href$/)) {
+						return this.attributes[a];
+					}
 				}
 				return svg.EmptyProperty;
 			}
-			
+
 			// get or create style, crawls up node tree
 			this.style = function(name, createIfNotExists, skipAncestors) {
 				var s = this.styles[name];
 				if (s != null) return s;
-				
+
 				var a = this.attribute(name);
 				if (a != null && a.hasValue()) {
 					this.styles[name] = a; // move up to me to cache
 					return a;
 				}
-				
+
 				if (skipAncestors != true) {
 					var p = this.parent;
 					if (p != null) {
@@ -704,19 +767,19 @@
 						}
 					}
 				}
-					
+
 				if (createIfNotExists == true) { s = new svg.Property(name, ''); this.styles[name] = s; }
 				return s || svg.EmptyProperty;
 			}
-			
+
 			// base render
 			this.render = function(ctx) {
 				// don't render display=none
 				if (this.style('display').value == 'none') return;
-				
+
 				// don't render visibility=hidden
 				if (this.style('visibility').value == 'hidden') return;
-			
+
 				ctx.save();
 				if (this.attribute('mask').hasValue()) { // mask
 					var mask = this.attribute('mask').getDefinition();
@@ -726,82 +789,65 @@
 					var filter = this.style('filter').getDefinition();
 					if (filter != null) filter.apply(ctx, this);
 				}
-				else {	
+				else {
 					this.setContext(ctx);
-					this.renderChildren(ctx);	
-					this.clearContext(ctx);							
+					this.renderChildren(ctx);
+					this.clearContext(ctx);
 				}
 				ctx.restore();
 			}
-			
+
 			// base set context
 			this.setContext = function(ctx) {
 				// OVERRIDE ME!
 			}
-			
+
 			// base clear context
 			this.clearContext = function(ctx) {
 				// OVERRIDE ME!
-			}			
-			
+			}
+
 			// base render children
 			this.renderChildren = function(ctx) {
 				for (var i=0; i<this.children.length; i++) {
 					this.children[i].render(ctx);
 				}
 			}
-			
+
 			this.addChild = function(childNode, create) {
 				var child = childNode;
 				if (create) child = svg.CreateElement(childNode);
 				child.parent = this;
 				if (child.type != 'title') { this.children.push(child);	}
 			}
-				
+
 			if (node != null && node.nodeType == 1) { //ELEMENT_NODE
 				// add attributes
 				for (var i=0; i<node.attributes.length; i++) {
 					var attribute = node.attributes[i];
 					this.attributes[attribute.nodeName] = new svg.Property(attribute.nodeName, attribute.nodeValue);
 				}
-										
-				// add tag styles
-				var styles = svg.Styles[node.nodeName];
-				if (styles != null) {
-					for (var name in styles) {
-						this.styles[name] = styles[name];
-					}
-				}					
-				
-				// add class styles
-				if (this.attribute('class').hasValue()) {
-					var classes = svg.compressSpaces(this.attribute('class').value).split(' ');
-					for (var j=0; j<classes.length; j++) {
-						styles = svg.Styles['.'+classes[j]];
+
+				// add styles
+				for (var selector in svg.Styles) {
+					if (matchesSelector(node, selector)) {
+						var styles = svg.Styles[selector];
+						var specificity = svg.StylesSpecificity[selector];
 						if (styles != null) {
 							for (var name in styles) {
-								this.styles[name] = styles[name];
-							}
-						}
-						styles = svg.Styles[node.nodeName+'.'+classes[j]];
-						if (styles != null) {
-							for (var name in styles) {
-								this.styles[name] = styles[name];
+								var existingSpecificity = this.stylesSpecificity[name];
+								if (typeof(existingSpecificity) == 'undefined') {
+									existingSpecificity = '000';
+								}
+								if (specificity > existingSpecificity) {
+									this.styles[name] = styles[name];
+									this.stylesSpecificity[name] = specificity;
+								}
 							}
 						}
 					}
 				}
-				
-				// add id styles
-				if (this.attribute('id').hasValue()) {
-					var styles = svg.Styles['#' + this.attribute('id').value];
-					if (styles != null) {
-						for (var name in styles) {
-							this.styles[name] = styles[name];
-						}
-					}
-				}
-				
+
 				// add inline styles
 				if (this.attribute('style').hasValue()) {
 					var styles = this.attribute('style').value.split(';');
@@ -813,7 +859,7 @@
 							this.styles[name] = new svg.Property(name, value);
 						}
 					}
-				}	
+				}
 
 				// add id
 				if (this.attribute('id').hasValue()) {
@@ -821,7 +867,7 @@
 						svg.Definitions[this.attribute('id').value] = this;
 					}
 				}
-				
+
 				// add children
 				for (var i=0; i<node.childNodes.length; i++) {
 					var childNode = node.childNodes[i];
@@ -835,11 +881,11 @@
 				}
 			}
 		}
-		
+
 		svg.Element.RenderedElementBase = function(node) {
 			this.base = svg.Element.ElementBase;
 			this.base(node);
-			
+
 			this.setContext = function(ctx) {
 				// fill
 				if (this.style('fill').isUrlDefinition()) {
@@ -856,7 +902,7 @@
 					fillStyle = fillStyle.addOpacity(this.style('fill-opacity'));
 					ctx.fillStyle = fillStyle.value;
 				}
-									
+
 				// stroke
 				if (this.style('stroke').isUrlDefinition()) {
 					var fs = this.style('stroke').getFillStyleDefinition(this, this.style('stroke-opacity'));
@@ -884,7 +930,7 @@
 					if (typeof(ctx.setLineDash) != 'undefined') { ctx.setLineDash(gaps); }
 					else if (typeof(ctx.webkitLineDash) != 'undefined') { ctx.webkitLineDash = gaps; }
 					else if (typeof(ctx.mozDash) != 'undefined' && !(gaps.length==1 && gaps[0]==0)) { ctx.mozDash = gaps; }
-					
+
 					var offset = this.style('stroke-dashoffset').numValueOrDefault(1);
 					if (typeof(ctx.lineDashOffset) != 'undefined') { ctx.lineDashOffset = offset; }
 					else if (typeof(ctx.webkitLineDashOffset) != 'undefined') { ctx.webkitLineDashOffset = offset; }
@@ -893,43 +939,43 @@
 
 				// font
 				if (typeof(ctx.font) != 'undefined') {
-					ctx.font = svg.Font.CreateFont( 
-						this.style('font-style').value, 
-						this.style('font-variant').value, 
-						this.style('font-weight').value, 
-						this.style('font-size').hasValue() ? this.style('font-size').toPixels() + 'px' : '', 
+					ctx.font = svg.Font.CreateFont(
+						this.style('font-style').value,
+						this.style('font-variant').value,
+						this.style('font-weight').value,
+						this.style('font-size').hasValue() ? this.style('font-size').toPixels() + 'px' : '',
 						this.style('font-family').value).toString();
 				}
-				
+
 				// transform
-				if (this.attribute('transform').hasValue()) { 
+				if (this.attribute('transform').hasValue()) {
 					var transform = new svg.Transform(this.attribute('transform').value);
 					transform.apply(ctx);
 				}
-				
+
 				// clip
 				if (this.style('clip-path', false, true).hasValue()) {
 					var clip = this.style('clip-path', false, true).getDefinition();
 					if (clip != null) clip.apply(ctx);
 				}
-				
+
 				// opacity
 				if (this.style('opacity').hasValue()) {
 					ctx.globalAlpha = this.style('opacity').numValue();
 				}
-			}		
+			}
 		}
 		svg.Element.RenderedElementBase.prototype = new svg.Element.ElementBase;
-		
+
 		svg.Element.PathElementBase = function(node) {
 			this.base = svg.Element.RenderedElementBase;
 			this.base(node);
-			
+
 			this.path = function(ctx) {
 				if (ctx != null) ctx.beginPath();
 				return new svg.BoundingBox();
 			}
-			
+
 			this.renderChildren = function(ctx) {
 				this.path(ctx);
 				svg.Mouse.checkPath(this, ctx);
@@ -938,7 +984,7 @@
 					else { ctx.fill(); }
 				}
 				if (ctx.strokeStyle != '') ctx.stroke();
-				
+
 				var markers = this.getMarkers();
 				if (markers != null) {
 					if (this.style('marker-start').isUrlDefinition()) {
@@ -955,64 +1001,64 @@
 						var marker = this.style('marker-end').getDefinition();
 						marker.render(ctx, markers[markers.length-1][0], markers[markers.length-1][1]);
 					}
-				}					
+				}
 			}
-			
+
 			this.getBoundingBox = function() {
 				return this.path();
 			}
-			
+
 			this.getMarkers = function() {
 				return null;
 			}
 		}
 		svg.Element.PathElementBase.prototype = new svg.Element.RenderedElementBase;
-		
+
 		// svg element
 		svg.Element.svg = function(node) {
 			this.base = svg.Element.RenderedElementBase;
 			this.base(node);
-			
+
 			this.baseClearContext = this.clearContext;
 			this.clearContext = function(ctx) {
 				this.baseClearContext(ctx);
 				svg.ViewPort.RemoveCurrent();
 			}
-			
+
 			this.baseSetContext = this.setContext;
 			this.setContext = function(ctx) {
 				// initial values and defaults
 				ctx.strokeStyle = 'rgba(0,0,0,0)';
 				ctx.lineCap = 'butt';
 				ctx.lineJoin = 'miter';
-				ctx.miterLimit = 4;	
+				ctx.miterLimit = 4;
 				if (typeof(ctx.font) != 'undefined' && typeof(window.getComputedStyle) != 'undefined') {
 					ctx.font = window.getComputedStyle(ctx.canvas).getPropertyValue('font');
 				}
-			
+
 				this.baseSetContext(ctx);
-				
+
 				// create new view port
 				if (!this.attribute('x').hasValue()) this.attribute('x', true).value = 0;
 				if (!this.attribute('y').hasValue()) this.attribute('y', true).value = 0;
 				ctx.translate(this.attribute('x').toPixels('x'), this.attribute('y').toPixels('y'));
-				
+
 				var width = svg.ViewPort.width();
 				var height = svg.ViewPort.height();
-				
+
 				if (!this.attribute('width').hasValue()) this.attribute('width', true).value = '100%';
 				if (!this.attribute('height').hasValue()) this.attribute('height', true).value = '100%';
 				if (typeof(this.root) == 'undefined') {
 					width = this.attribute('width').toPixels('x');
 					height = this.attribute('height').toPixels('y');
-					
+
 					var x = 0;
 					var y = 0;
 					if (this.attribute('refX').hasValue() && this.attribute('refY').hasValue()) {
 						x = -this.attribute('refX').toPixels('x');
 						y = -this.attribute('refY').toPixels('y');
 					}
-					
+
 					if (this.attribute('overflow').valueOrDefault('hidden') != 'visible') {
 						ctx.beginPath();
 						ctx.moveTo(x, y);
@@ -1023,19 +1069,19 @@
 						ctx.clip();
 					}
 				}
-				svg.ViewPort.SetCurrent(width, height);	
-						
+				svg.ViewPort.SetCurrent(width, height);
+
 				// viewbox
-				if (this.attribute('viewBox').hasValue()) {				
+				if (this.attribute('viewBox').hasValue()) {
 					var viewBox = svg.ToNumberArray(this.attribute('viewBox').value);
 					var minX = viewBox[0];
 					var minY = viewBox[1];
 					width = viewBox[2];
 					height = viewBox[3];
-					
+
 					svg.AspectRatio(ctx,
-									this.attribute('preserveAspectRatio').value, 
-									svg.ViewPort.width(), 
+									this.attribute('preserveAspectRatio').value,
+									svg.ViewPort.width(),
 									width,
 									svg.ViewPort.height(),
 									height,
@@ -1043,10 +1089,10 @@
 									minY,
 									this.attribute('refX').value,
 									this.attribute('refY').value);
-					
+
 					svg.ViewPort.RemoveCurrent();
 					svg.ViewPort.SetCurrent(viewBox[2], viewBox[3]);
-				}				
+				}
 			}
 		}
 		svg.Element.svg.prototype = new svg.Element.RenderedElementBase;
@@ -1055,7 +1101,7 @@
 		svg.Element.rect = function(node) {
 			this.base = svg.Element.PathElementBase;
 			this.base(node);
-			
+
 			this.path = function(ctx) {
 				var x = this.attribute('x').toPixels('x');
 				var y = this.attribute('y').toPixels('y');
@@ -1080,45 +1126,45 @@
 					ctx.quadraticCurveTo(x, y, x + rx, y)
 					ctx.closePath();
 				}
-				
+
 				return new svg.BoundingBox(x, y, x + width, y + height);
 			}
 		}
 		svg.Element.rect.prototype = new svg.Element.PathElementBase;
-		
+
 		// circle element
 		svg.Element.circle = function(node) {
 			this.base = svg.Element.PathElementBase;
 			this.base(node);
-			
+
 			this.path = function(ctx) {
 				var cx = this.attribute('cx').toPixels('x');
 				var cy = this.attribute('cy').toPixels('y');
 				var r = this.attribute('r').toPixels();
-			
+
 				if (ctx != null) {
 					ctx.beginPath();
-					ctx.arc(cx, cy, r, 0, Math.PI * 2, true); 
+					ctx.arc(cx, cy, r, 0, Math.PI * 2, true);
 					ctx.closePath();
 				}
-				
+
 				return new svg.BoundingBox(cx - r, cy - r, cx + r, cy + r);
 			}
 		}
-		svg.Element.circle.prototype = new svg.Element.PathElementBase;	
+		svg.Element.circle.prototype = new svg.Element.PathElementBase;
 
 		// ellipse element
 		svg.Element.ellipse = function(node) {
 			this.base = svg.Element.PathElementBase;
 			this.base(node);
-			
+
 			this.path = function(ctx) {
 				var KAPPA = 4 * ((Math.sqrt(2) - 1) / 3);
 				var rx = this.attribute('rx').toPixels('x');
 				var ry = this.attribute('ry').toPixels('y');
 				var cx = this.attribute('cx').toPixels('x');
 				var cy = this.attribute('cy').toPixels('y');
-				
+
 				if (ctx != null) {
 					ctx.beginPath();
 					ctx.moveTo(cx, cy - ry);
@@ -1128,48 +1174,48 @@
 					ctx.bezierCurveTo(cx - rx, cy - (KAPPA * ry), cx - (KAPPA * rx), cy - ry, cx, cy - ry);
 					ctx.closePath();
 				}
-				
+
 				return new svg.BoundingBox(cx - rx, cy - ry, cx + rx, cy + ry);
 			}
 		}
-		svg.Element.ellipse.prototype = new svg.Element.PathElementBase;			
-		
+		svg.Element.ellipse.prototype = new svg.Element.PathElementBase;
+
 		// line element
 		svg.Element.line = function(node) {
 			this.base = svg.Element.PathElementBase;
 			this.base(node);
-			
+
 			this.getPoints = function() {
 				return [
 					new svg.Point(this.attribute('x1').toPixels('x'), this.attribute('y1').toPixels('y')),
 					new svg.Point(this.attribute('x2').toPixels('x'), this.attribute('y2').toPixels('y'))];
 			}
-								
+
 			this.path = function(ctx) {
 				var points = this.getPoints();
-				
+
 				if (ctx != null) {
 					ctx.beginPath();
 					ctx.moveTo(points[0].x, points[0].y);
 					ctx.lineTo(points[1].x, points[1].y);
 				}
-				
+
 				return new svg.BoundingBox(points[0].x, points[0].y, points[1].x, points[1].y);
 			}
-			
+
 			this.getMarkers = function() {
-				var points = this.getPoints();	
+				var points = this.getPoints();
 				var a = points[0].angleTo(points[1]);
 				return [[points[0], a], [points[1], a]];
 			}
 		}
-		svg.Element.line.prototype = new svg.Element.PathElementBase;		
-				
+		svg.Element.line.prototype = new svg.Element.PathElementBase;
+
 		// polyline element
 		svg.Element.polyline = function(node) {
 			this.base = svg.Element.PathElementBase;
 			this.base(node);
-			
+
 			this.points = svg.CreatePath(this.attribute('points').value);
 			this.path = function(ctx) {
 				var bb = new svg.BoundingBox(this.points[0].x, this.points[0].y);
@@ -1183,7 +1229,7 @@
 				}
 				return bb;
 			}
-			
+
 			this.getMarkers = function() {
 				var markers = [];
 				for (var i=0; i<this.points.length - 1; i++) {
@@ -1191,15 +1237,15 @@
 				}
 				markers.push([this.points[this.points.length-1], markers[markers.length-1][1]]);
 				return markers;
-			}			
+			}
 		}
-		svg.Element.polyline.prototype = new svg.Element.PathElementBase;				
-				
+		svg.Element.polyline.prototype = new svg.Element.PathElementBase;
+
 		// polygon element
 		svg.Element.polygon = function(node) {
 			this.base = svg.Element.polyline;
 			this.base(node);
-			
+
 			this.basePath = this.path;
 			this.path = function(ctx) {
 				var bb = this.basePath(ctx);
@@ -1216,7 +1262,7 @@
 		svg.Element.path = function(node) {
 			this.base = svg.Element.PathElementBase;
 			this.base(node);
-					
+
 			var d = this.attribute('d').value;
 			// TODO: convert to real lexer based on http://www.w3.org/TR/SVG11/paths.html#PathDataBNF
 			d = d.replace(/,/gm,' '); // get rid of all commas
@@ -1231,7 +1277,7 @@
 			d = svg.trim(d);
 			this.PathParser = new (function(d) {
 				this.tokens = d.split(' ');
-				
+
 				this.reset = function() {
 					this.i = -1;
 					this.command = '';
@@ -1242,16 +1288,16 @@
 					this.points = [];
 					this.angles = [];
 				}
-								
+
 				this.isEnd = function() {
 					return this.i >= this.tokens.length - 1;
 				}
-				
+
 				this.isCommandOrEnd = function() {
 					if (this.isEnd()) return true;
 					return this.tokens[this.i + 1].match(/^[A-Za-z]$/) != null;
 				}
-				
+
 				this.isRelativeCommand = function() {
 					switch(this.command)
 					{
@@ -1270,51 +1316,51 @@
 					}
 					return false;
 				}
-							
+
 				this.getToken = function() {
 					this.i++;
 					return this.tokens[this.i];
 				}
-				
+
 				this.getScalar = function() {
 					return parseFloat(this.getToken());
 				}
-				
+
 				this.nextCommand = function() {
 					this.previousCommand = this.command;
 					this.command = this.getToken();
-				}				
-				
+				}
+
 				this.getPoint = function() {
 					var p = new svg.Point(this.getScalar(), this.getScalar());
 					return this.makeAbsolute(p);
 				}
-				
+
 				this.getAsControlPoint = function() {
 					var p = this.getPoint();
 					this.control = p;
 					return p;
 				}
-				
+
 				this.getAsCurrentPoint = function() {
 					var p = this.getPoint();
 					this.current = p;
-					return p;	
+					return p;
 				}
-				
+
 				this.getReflectedControlPoint = function() {
-					if (this.previousCommand.toLowerCase() != 'c' && 
+					if (this.previousCommand.toLowerCase() != 'c' &&
 					    this.previousCommand.toLowerCase() != 's' &&
-						this.previousCommand.toLowerCase() != 'q' && 
+						this.previousCommand.toLowerCase() != 'q' &&
 						this.previousCommand.toLowerCase() != 't' ){
 						return this.current;
 					}
-					
+
 					// reflect point
-					var p = new svg.Point(2 * this.current.x - this.control.x, 2 * this.current.y - this.control.y);					
+					var p = new svg.Point(2 * this.current.x - this.control.x, 2 * this.current.y - this.control.y);
 					return p;
 				}
-				
+
 				this.makeAbsolute = function(p) {
 					if (this.isRelativeCommand()) {
 						p.x += this.current.x;
@@ -1322,7 +1368,7 @@
 					}
 					return p;
 				}
-				
+
 				this.addMarker = function(p, from, priorTo) {
 					// if the last angle isn't filled in because we didn't have this point yet ...
 					if (priorTo != null && this.angles.length > 0 && this.angles[this.angles.length-1] == null) {
@@ -1330,12 +1376,12 @@
 					}
 					this.addMarkerAngle(p, from == null ? null : from.angleTo(p));
 				}
-				
+
 				this.addMarkerAngle = function(p, a) {
 					this.points.push(p);
 					this.angles.push(a);
-				}				
-				
+				}
+
 				this.getMarkerPoints = function() { return this.points; }
 				this.getMarkerAngles = function() {
 					for (var i=0; i<this.angles.length; i++) {
@@ -1542,7 +1588,7 @@
 			this.getMarkers = function() {
 				var points = this.PathParser.getMarkerPoints();
 				var angles = this.PathParser.getMarkerAngles();
-				
+
 				var markers = [];
 				for (var i=0; i<points.length; i++) {
 					markers.push([points[i], angles[i]]);
@@ -1551,16 +1597,16 @@
 			}
 		}
 		svg.Element.path.prototype = new svg.Element.PathElementBase;
-		
+
 		// pattern element
 		svg.Element.pattern = function(node) {
 			this.base = svg.Element.ElementBase;
 			this.base(node);
-			
+
 			this.createPattern = function(ctx, element) {
 				var width = this.attribute('width').toPixels('x', true);
 				var height = this.attribute('height').toPixels('y', true);
-			
+
 				// render me using a temporary svg element
 				var tempSvg = new svg.Element.svg();
 				tempSvg.attributes['viewBox'] = new svg.Property('viewBox', this.attribute('viewBox').value);
@@ -1568,7 +1614,7 @@
 				tempSvg.attributes['height'] = new svg.Property('height', height + 'px');
 				tempSvg.attributes['transform'] = new svg.Property('transform', this.attribute('patternTransform').value);
 				tempSvg.children = this.children;
-				
+
 				var c = document.createElement('canvas');
 				c.width = width;
 				c.height = height;
@@ -1590,19 +1636,19 @@
 			}
 		}
 		svg.Element.pattern.prototype = new svg.Element.ElementBase;
-		
+
 		// marker element
 		svg.Element.marker = function(node) {
 			this.base = svg.Element.ElementBase;
 			this.base(node);
-			
+
 			this.baseRender = this.render;
 			this.render = function(ctx, point, angle) {
 				ctx.translate(point.x, point.y);
 				if (this.attribute('orient').valueOrDefault('auto') == 'auto') ctx.rotate(angle);
 				if (this.attribute('markerUnits').valueOrDefault('strokeWidth') == 'strokeWidth') ctx.scale(ctx.lineWidth, ctx.lineWidth);
 				ctx.save();
-							
+
 				// render me using a temporary svg element
 				var tempSvg = new svg.Element.svg();
 				tempSvg.attributes['viewBox'] = new svg.Property('viewBox', this.attribute('viewBox').value);
@@ -1614,7 +1660,7 @@
 				tempSvg.attributes['stroke'] = new svg.Property('stroke', this.attribute('stroke').valueOrDefault('none'));
 				tempSvg.children = this.children;
 				tempSvg.render(ctx);
-				
+
 				ctx.restore();
 				if (this.attribute('markerUnits').valueOrDefault('strokeWidth') == 'strokeWidth') ctx.scale(1/ctx.lineWidth, 1/ctx.lineWidth);
 				if (this.attribute('orient').valueOrDefault('auto') == 'auto') ctx.rotate(-angle);
@@ -1622,41 +1668,41 @@
 			}
 		}
 		svg.Element.marker.prototype = new svg.Element.ElementBase;
-		
+
 		// definitions element
 		svg.Element.defs = function(node) {
 			this.base = svg.Element.ElementBase;
-			this.base(node);	
-			
+			this.base(node);
+
 			this.render = function(ctx) {
 				// NOOP
 			}
 		}
 		svg.Element.defs.prototype = new svg.Element.ElementBase;
-		
+
 		// base for gradients
 		svg.Element.GradientBase = function(node) {
 			this.base = svg.Element.ElementBase;
 			this.base(node);
-			
+
 			this.gradientUnits = this.attribute('gradientUnits').valueOrDefault('objectBoundingBox');
-			
-			this.stops = [];			
+
+			this.stops = [];
 			for (var i=0; i<this.children.length; i++) {
 				var child = this.children[i];
 				if (child.type == 'stop') this.stops.push(child);
-			}	
-			
+			}
+
 			this.getGradient = function() {
 				// OVERRIDE ME!
-			}			
+			}
 
 			this.createGradient = function(ctx, element, parentOpacityProp) {
 				var stopsContainer = this;
 				if (this.getHrefAttribute().hasValue()) {
 					stopsContainer = this.getHrefAttribute().getDefinition();
 				}
-				
+
 				var addParentOpacity = function (color) {
 					if (parentOpacityProp.hasValue()) {
 						var p = new svg.Property('color', color);
@@ -1664,56 +1710,56 @@
 					}
 					return color;
 				};
-			
+
 				var g = this.getGradient(ctx, element);
 				if (g == null) return addParentOpacity(stopsContainer.stops[stopsContainer.stops.length - 1].color);
 				for (var i=0; i<stopsContainer.stops.length; i++) {
 					g.addColorStop(stopsContainer.stops[i].offset, addParentOpacity(stopsContainer.stops[i].color));
 				}
-				
+
 				if (this.attribute('gradientTransform').hasValue()) {
 					// render as transformed pattern on temporary canvas
 					var rootView = svg.ViewPort.viewPorts[0];
-					
+
 					var rect = new svg.Element.rect();
 					rect.attributes['x'] = new svg.Property('x', -svg.MAX_VIRTUAL_PIXELS/3.0);
 					rect.attributes['y'] = new svg.Property('y', -svg.MAX_VIRTUAL_PIXELS/3.0);
 					rect.attributes['width'] = new svg.Property('width', svg.MAX_VIRTUAL_PIXELS);
 					rect.attributes['height'] = new svg.Property('height', svg.MAX_VIRTUAL_PIXELS);
-					
+
 					var group = new svg.Element.g();
 					group.attributes['transform'] = new svg.Property('transform', this.attribute('gradientTransform').value);
 					group.children = [ rect ];
-					
+
 					var tempSvg = new svg.Element.svg();
 					tempSvg.attributes['x'] = new svg.Property('x', 0);
 					tempSvg.attributes['y'] = new svg.Property('y', 0);
 					tempSvg.attributes['width'] = new svg.Property('width', rootView.width);
 					tempSvg.attributes['height'] = new svg.Property('height', rootView.height);
 					tempSvg.children = [ group ];
-					
+
 					var c = document.createElement('canvas');
 					c.width = rootView.width;
 					c.height = rootView.height;
 					var tempCtx = c.getContext('2d');
 					tempCtx.fillStyle = g;
-					tempSvg.render(tempCtx);		
+					tempSvg.render(tempCtx);
 					return tempCtx.createPattern(c, 'no-repeat');
 				}
-				
-				return g;				
+
+				return g;
 			}
 		}
 		svg.Element.GradientBase.prototype = new svg.Element.ElementBase;
-		
+
 		// linear gradient element
 		svg.Element.linearGradient = function(node) {
 			this.base = svg.Element.GradientBase;
 			this.base(node);
-			
+
 			this.getGradient = function(ctx, element) {
 				var bb = this.gradientUnits == 'objectBoundingBox' ? element.getBoundingBox() : null;
-				
+
 				if (!this.attribute('x1').hasValue()
 				 && !this.attribute('y1').hasValue()
 				 && !this.attribute('x2').hasValue()
@@ -1723,17 +1769,17 @@
 					this.attribute('x2', true).value = 1;
 					this.attribute('y2', true).value = 0;
 				 }
-				
-				var x1 = (this.gradientUnits == 'objectBoundingBox' 
-					? bb.x() + bb.width() * this.attribute('x1').numValue() 
+
+				var x1 = (this.gradientUnits == 'objectBoundingBox'
+					? bb.x() + bb.width() * this.attribute('x1').numValue()
 					: this.attribute('x1').toPixels('x'));
-				var y1 = (this.gradientUnits == 'objectBoundingBox' 
+				var y1 = (this.gradientUnits == 'objectBoundingBox'
 					? bb.y() + bb.height() * this.attribute('y1').numValue()
 					: this.attribute('y1').toPixels('y'));
-				var x2 = (this.gradientUnits == 'objectBoundingBox' 
+				var x2 = (this.gradientUnits == 'objectBoundingBox'
 					? bb.x() + bb.width() * this.attribute('x2').numValue()
 					: this.attribute('x2').toPixels('x'));
-				var y2 = (this.gradientUnits == 'objectBoundingBox' 
+				var y2 = (this.gradientUnits == 'objectBoundingBox'
 					? bb.y() + bb.height() * this.attribute('y2').numValue()
 					: this.attribute('y2').toPixels('y'));
 
@@ -1742,100 +1788,100 @@
 			}
 		}
 		svg.Element.linearGradient.prototype = new svg.Element.GradientBase;
-		
+
 		// radial gradient element
 		svg.Element.radialGradient = function(node) {
 			this.base = svg.Element.GradientBase;
 			this.base(node);
-			
+
 			this.getGradient = function(ctx, element) {
 				var bb = element.getBoundingBox();
-				
+
 				if (!this.attribute('cx').hasValue()) this.attribute('cx', true).value = '50%';
 				if (!this.attribute('cy').hasValue()) this.attribute('cy', true).value = '50%';
 				if (!this.attribute('r').hasValue()) this.attribute('r', true).value = '50%';
-				
-				var cx = (this.gradientUnits == 'objectBoundingBox' 
-					? bb.x() + bb.width() * this.attribute('cx').numValue() 
+
+				var cx = (this.gradientUnits == 'objectBoundingBox'
+					? bb.x() + bb.width() * this.attribute('cx').numValue()
 					: this.attribute('cx').toPixels('x'));
-				var cy = (this.gradientUnits == 'objectBoundingBox' 
-					? bb.y() + bb.height() * this.attribute('cy').numValue() 
+				var cy = (this.gradientUnits == 'objectBoundingBox'
+					? bb.y() + bb.height() * this.attribute('cy').numValue()
 					: this.attribute('cy').toPixels('y'));
-				
+
 				var fx = cx;
 				var fy = cy;
 				if (this.attribute('fx').hasValue()) {
-					fx = (this.gradientUnits == 'objectBoundingBox' 
-					? bb.x() + bb.width() * this.attribute('fx').numValue() 
+					fx = (this.gradientUnits == 'objectBoundingBox'
+					? bb.x() + bb.width() * this.attribute('fx').numValue()
 					: this.attribute('fx').toPixels('x'));
 				}
 				if (this.attribute('fy').hasValue()) {
-					fy = (this.gradientUnits == 'objectBoundingBox' 
-					? bb.y() + bb.height() * this.attribute('fy').numValue() 
+					fy = (this.gradientUnits == 'objectBoundingBox'
+					? bb.y() + bb.height() * this.attribute('fy').numValue()
 					: this.attribute('fy').toPixels('y'));
 				}
-				
-				var r = (this.gradientUnits == 'objectBoundingBox' 
+
+				var r = (this.gradientUnits == 'objectBoundingBox'
 					? (bb.width() + bb.height()) / 2.0 * this.attribute('r').numValue()
 					: this.attribute('r').toPixels());
-				
+
 				return ctx.createRadialGradient(fx, fy, 0, cx, cy, r);
 			}
 		}
 		svg.Element.radialGradient.prototype = new svg.Element.GradientBase;
-		
+
 		// gradient stop element
 		svg.Element.stop = function(node) {
 			this.base = svg.Element.ElementBase;
 			this.base(node);
-			
+
 			this.offset = this.attribute('offset').numValue();
 			if (this.offset < 0) this.offset = 0;
 			if (this.offset > 1) this.offset = 1;
-			
+
 			var stopColor = this.style('stop-color');
 			if (this.style('stop-opacity').hasValue()) stopColor = stopColor.addOpacity(this.style('stop-opacity'));
 			this.color = stopColor.value;
 		}
 		svg.Element.stop.prototype = new svg.Element.ElementBase;
-		
+
 		// animation base element
 		svg.Element.AnimateBase = function(node) {
 			this.base = svg.Element.ElementBase;
 			this.base(node);
-			
+
 			svg.Animations.push(this);
-			
+
 			this.duration = 0.0;
 			this.begin = this.attribute('begin').toMilliseconds();
 			this.maxDuration = this.begin + this.attribute('dur').toMilliseconds();
-			
+
 			this.getProperty = function() {
 				var attributeType = this.attribute('attributeType').value;
 				var attributeName = this.attribute('attributeName').value;
-				
+
 				if (attributeType == 'CSS') {
 					return this.parent.style(attributeName, true);
 				}
-				return this.parent.attribute(attributeName, true);			
+				return this.parent.attribute(attributeName, true);
 			};
-			
+
 			this.initialValue = null;
 			this.initialUnits = '';
-			this.removed = false;		
+			this.removed = false;
 
 			this.calcValue = function() {
 				// OVERRIDE ME!
 				return '';
 			}
-					
-			this.update = function(delta) {	
+
+			this.update = function(delta) {
 				// set initial value
 				if (this.initialValue == null) {
 					this.initialValue = this.getProperty().value;
 					this.initialUnits = this.getProperty().getUnits();
 				}
-			
+
 				// if we're past the end time
 				if (this.duration > this.maxDuration) {
 					// loop for indefinitely repeating animations
@@ -1854,32 +1900,32 @@
 						return true;
 					}
 					return false;
-				}			
+				}
 				this.duration = this.duration + delta;
-			
+
 				// if we're past the begin time
 				var updated = false;
 				if (this.begin < this.duration) {
 					var newValue = this.calcValue(); // tween
-					
+
 					if (this.attribute('type').hasValue()) {
 						// for transform, etc.
 						var type = this.attribute('type').value;
 						newValue = type + '(' + newValue + ')';
 					}
-					
+
 					this.getProperty().value = newValue;
 					updated = true;
 				}
-				
+
 				return updated;
 			}
-			
+
 			this.from = this.attribute('from');
 			this.to = this.attribute('to');
 			this.values = this.attribute('values');
 			if (this.values.hasValue()) this.values.value = this.values.value.split(';');
-			
+
 			// fraction of duration we've covered
 			this.progress = function() {
 				var ret = { progress: (this.duration - this.begin) / (this.maxDuration - this.begin) };
@@ -1895,25 +1941,25 @@
 					ret.to = this.to;
 				}
 				return ret;
-			}			
+			}
 		}
 		svg.Element.AnimateBase.prototype = new svg.Element.ElementBase;
-		
+
 		// animate element
 		svg.Element.animate = function(node) {
 			this.base = svg.Element.AnimateBase;
 			this.base(node);
-			
+
 			this.calcValue = function() {
 				var p = this.progress();
-				
+
 				// tween value linearly
-				var newValue = p.from.numValue() + (p.to.numValue() - p.from.numValue()) * p.progress; 
+				var newValue = p.from.numValue() + (p.to.numValue() - p.from.numValue()) * p.progress;
 				return newValue + this.initialUnits;
 			};
 		}
 		svg.Element.animate.prototype = new svg.Element.AnimateBase;
-			
+
 		// animate color element
 		svg.Element.animateColor = function(node) {
 			this.base = svg.Element.AnimateBase;
@@ -1923,7 +1969,7 @@
 				var p = this.progress();
 				var from = new RGBColor(p.from.value);
 				var to = new RGBColor(p.to.value);
-				
+
 				if (from.ok && to.ok) {
 					// tween color linearly
 					var r = from.r + (to.r - from.r) * p.progress;
@@ -1935,15 +1981,15 @@
 			};
 		}
 		svg.Element.animateColor.prototype = new svg.Element.AnimateBase;
-		
+
 		// animate transform element
 		svg.Element.animateTransform = function(node) {
 			this.base = svg.Element.AnimateBase;
 			this.base(node);
-			
+
 			this.calcValue = function() {
 				var p = this.progress();
-				
+
 				// tween value linearly
 				var from = svg.ToNumberArray(p.from.value);
 				var to = svg.ToNumberArray(p.to.value);
@@ -1955,19 +2001,19 @@
 			};
 		}
 		svg.Element.animateTransform.prototype = new svg.Element.animate;
-		
+
 		// font element
 		svg.Element.font = function(node) {
 			this.base = svg.Element.ElementBase;
 			this.base(node);
 
-			this.horizAdvX = this.attribute('horiz-adv-x').numValue();			
-			
+			this.horizAdvX = this.attribute('horiz-adv-x').numValue();
+
 			this.isRTL = false;
 			this.isArabic = false;
 			this.fontFace = null;
 			this.missingGlyph = null;
-			this.glyphs = [];			
+			this.glyphs = [];
 			for (var i=0; i<this.children.length; i++) {
 				var child = this.children[i];
 				if (child.type == 'font-face') {
@@ -1988,63 +2034,63 @@
 						this.glyphs[child.unicode] = child;
 					}
 				}
-			}	
+			}
 		}
 		svg.Element.font.prototype = new svg.Element.ElementBase;
-		
+
 		// font-face element
 		svg.Element.fontface = function(node) {
 			this.base = svg.Element.ElementBase;
-			this.base(node);	
-			
+			this.base(node);
+
 			this.ascent = this.attribute('ascent').value;
 			this.descent = this.attribute('descent').value;
-			this.unitsPerEm = this.attribute('units-per-em').numValue();				
+			this.unitsPerEm = this.attribute('units-per-em').numValue();
 		}
 		svg.Element.fontface.prototype = new svg.Element.ElementBase;
-		
+
 		// missing-glyph element
 		svg.Element.missingglyph = function(node) {
 			this.base = svg.Element.path;
-			this.base(node);	
-			
+			this.base(node);
+
 			this.horizAdvX = 0;
 		}
 		svg.Element.missingglyph.prototype = new svg.Element.path;
-		
+
 		// glyph element
 		svg.Element.glyph = function(node) {
 			this.base = svg.Element.path;
-			this.base(node);	
-			
+			this.base(node);
+
 			this.horizAdvX = this.attribute('horiz-adv-x').numValue();
 			this.unicode = this.attribute('unicode').value;
 			this.arabicForm = this.attribute('arabic-form').value;
 		}
 		svg.Element.glyph.prototype = new svg.Element.path;
-		
+
 		// text element
 		svg.Element.text = function(node) {
 			this.captureTextNodes = true;
 			this.base = svg.Element.RenderedElementBase;
 			this.base(node);
-			
+
 			this.baseSetContext = this.setContext;
 			this.setContext = function(ctx) {
 				this.baseSetContext(ctx);
-				
+
 				var textBaseline = this.style('dominant-baseline').toTextBaseline();
 				if (textBaseline == null) textBaseline = this.style('alignment-baseline').toTextBaseline();
 				if (textBaseline != null) ctx.textBaseline = textBaseline;
 			}
-			
+
 			this.getBoundingBox = function () {
 				var x = this.attribute('x').toPixels('x');
 				var y = this.attribute('y').toPixels('y');
 				var fontSize = this.parent.style('font-size').numValueOrDefault(svg.Font.Parse(svg.ctx.font).fontSize);
 				return new svg.BoundingBox(x, y - fontSize, x + Math.floor(fontSize * 2.0 / 3.0) * this.children[0].getText().length, y);
 			}
-			
+
 			this.renderChildren = function(ctx) {
 				this.x = this.attribute('x').toPixels('x');
 				this.y = this.attribute('y').toPixels('y');
@@ -2053,7 +2099,7 @@
 					this.renderChild(ctx, this, i);
 				}
 			}
-			
+
 			this.getAnchorDelta = function (ctx, parent, startI) {
 				var textAnchor = this.style('text-anchor').valueOrDefault('start');
 				if (textAnchor != 'start') {
@@ -2067,7 +2113,7 @@
 				}
 				return 0;
 			}
-			
+
 			this.renderChild = function(ctx, parent, i) {
 				var child = parent.children[i];
 				if (child.attribute('x').hasValue()) {
@@ -2080,7 +2126,7 @@
 					child.x = this.x;
 				}
 				this.x = child.x + child.measureText(ctx);
-				
+
 				if (child.attribute('y').hasValue()) {
 					child.y = child.attribute('y').toPixels('y');
 					if (child.attribute('dy').hasValue()) child.y += child.attribute('dy').toPixels('y');
@@ -2091,27 +2137,27 @@
 					child.y = this.y;
 				}
 				this.y = child.y;
-				
+
 				child.render(ctx);
-				
+
 				for (var i=0; i<child.children.length; i++) {
 					this.renderChild(ctx, child, i);
 				}
 			}
 		}
 		svg.Element.text.prototype = new svg.Element.RenderedElementBase;
-		
+
 		// text base
 		svg.Element.TextElementBase = function(node) {
 			this.base = svg.Element.RenderedElementBase;
 			this.base(node);
-			
+
 			this.getGlyph = function(font, text, i) {
 				var c = text[i];
 				var glyph = null;
 				if (font.isArabic) {
 					var arabicForm = 'isolated';
-					if ((i==0 || text[i-1]==' ') && i<text.length-2 && text[i+1]!=' ') arabicForm = 'terminal'; 
+					if ((i==0 || text[i-1]==' ') && i<text.length-2 && text[i+1]!=' ') arabicForm = 'terminal';
 					if (i>0 && text[i-1]!=' ' && i<text.length-2 && text[i+1]!=' ') arabicForm = 'medial';
 					if (i>0 && text[i-1]!=' ' && (i == text.length-1 || text[i+1]==' ')) arabicForm = 'initial';
 					if (typeof(font.glyphs[c]) != 'undefined') {
@@ -2125,7 +2171,7 @@
 				if (glyph == null) glyph = font.missingGlyph;
 				return glyph;
 			}
-			
+
 			this.renderChildren = function(ctx) {
 				var customFont = this.parent.style('font-family').getDefinition();
 				if (customFont != null) {
@@ -2133,7 +2179,7 @@
 					var fontStyle = this.parent.style('font-style').valueOrDefault(svg.Font.Parse(svg.ctx.font).fontStyle);
 					var text = this.getText();
 					if (customFont.isRTL) text = text.split("").reverse().join("");
-					
+
 					var dx = svg.ToNumberArray(this.parent.attribute('dx').value);
 					for (var i=0; i<text.length; i++) {
 						var glyph = this.getGlyph(customFont, text, i);
@@ -2147,8 +2193,8 @@
 						if (fontStyle == 'italic') ctx.transform(1, 0, -.4, 1, 0, 0);
 						ctx.lineWidth = lw;
 						ctx.scale(1/scale, -1/scale);
-						ctx.translate(-this.x, -this.y);	
-						
+						ctx.translate(-this.x, -this.y);
+
 						this.x += fontSize * (glyph.horizAdvX || customFont.horizAdvX) / customFont.fontFace.unitsPerEm;
 						if (typeof(dx[i]) != 'undefined' && !isNaN(dx[i])) {
 							this.x += dx[i];
@@ -2156,15 +2202,15 @@
 					}
 					return;
 				}
-			
+
 				if (ctx.fillStyle != '') ctx.fillText(svg.compressSpaces(this.getText()), this.x, this.y);
 				if (ctx.strokeStyle != '') ctx.strokeText(svg.compressSpaces(this.getText()), this.x, this.y);
 			}
-			
+
 			this.getText = function() {
 				// OVERRIDE ME
 			}
-			
+
 			this.measureTextRecursive = function(ctx) {
 				var width = this.measureText(ctx);
 				for (var i=0; i<this.children.length; i++) {
@@ -2172,7 +2218,7 @@
 				}
 				return width;
 			}
-			
+
 			this.measureText = function(ctx) {
 				var customFont = this.parent.style('font-family').getDefinition();
 				if (customFont != null) {
@@ -2190,10 +2236,10 @@
 					}
 					return measure;
 				}
-			
+
 				var textToMeasure = svg.compressSpaces(this.getText());
 				if (!ctx.measureText) return textToMeasure.length * 10;
-				
+
 				ctx.save();
 				this.setContext(ctx);
 				var width = ctx.measureText(textToMeasure).width;
@@ -2202,47 +2248,47 @@
 			}
 		}
 		svg.Element.TextElementBase.prototype = new svg.Element.RenderedElementBase;
-		
-		// tspan 
+
+		// tspan
 		svg.Element.tspan = function(node) {
 			this.captureTextNodes = true;
 			this.base = svg.Element.TextElementBase;
 			this.base(node);
-			
+
 			this.text = node.nodeValue || node.text || '';
 			this.getText = function() {
 				return this.text;
 			}
 		}
 		svg.Element.tspan.prototype = new svg.Element.TextElementBase;
-		
+
 		// tref
 		svg.Element.tref = function(node) {
 			this.base = svg.Element.TextElementBase;
 			this.base(node);
-			
+
 			this.getText = function() {
 				var element = this.getHrefAttribute().getDefinition();
 				if (element != null) return element.children[0].getText();
 			}
 		}
-		svg.Element.tref.prototype = new svg.Element.TextElementBase;		
-		
+		svg.Element.tref.prototype = new svg.Element.TextElementBase;
+
 		// a element
 		svg.Element.a = function(node) {
 			this.base = svg.Element.TextElementBase;
 			this.base(node);
-			
+
 			this.hasText = node.childNodes.length > 0;
 			for (var i=0; i<node.childNodes.length; i++) {
 				if (node.childNodes[i].nodeType != 3) this.hasText = false;
 			}
-			
+
 			// this might contain text
 			this.text = this.hasText ? node.childNodes[0].nodeValue : '';
 			this.getText = function() {
 				return this.text;
-			}		
+			}
 
 			this.baseRenderChildren = this.renderChildren;
 			this.renderChildren = function(ctx) {
@@ -2250,7 +2296,7 @@
 					// render as text element
 					this.baseRenderChildren(ctx);
 					var fontSize = new svg.Property('fontSize', svg.Font.Parse(svg.ctx.font).fontSize);
-					svg.Mouse.checkBoundingBox(this, new svg.BoundingBox(this.x, this.y - fontSize.toPixels('y'), this.x + this.measureText(ctx), this.y));					
+					svg.Mouse.checkBoundingBox(this, new svg.BoundingBox(this.x, this.y - fontSize.toPixels('y'), this.x + this.measureText(ctx), this.y));
 				}
 				else if (this.children.length > 0) {
 					// render as temporary group
@@ -2260,26 +2306,26 @@
 					g.render(ctx);
 				}
 			}
-			
+
 			this.onclick = function() {
 				window.open(this.getHrefAttribute().value);
 			}
-			
+
 			this.onmousemove = function() {
 				svg.ctx.canvas.style.cursor = 'pointer';
 			}
 		}
-		svg.Element.a.prototype = new svg.Element.TextElementBase;		
-		
+		svg.Element.a.prototype = new svg.Element.TextElementBase;
+
 		// image element
 		svg.Element.image = function(node) {
 			this.base = svg.Element.RenderedElementBase;
 			this.base(node);
-			
+
 			var href = this.getHrefAttribute().value;
 			if (href == '') { return; }
 			var isSvg = href.match(/\.svg$/)
-			
+
 			svg.Images.push(this);
 			this.loaded = false;
 			if (!isSvg) {
@@ -2294,15 +2340,15 @@
 				this.img = svg.ajax(href);
 				this.loaded = true;
 			}
-			
+
 			this.renderChildren = function(ctx) {
 				var x = this.attribute('x').toPixels('x');
 				var y = this.attribute('y').toPixels('y');
-				
+
 				var width = this.attribute('width').toPixels('x');
-				var height = this.attribute('height').toPixels('y');			
+				var height = this.attribute('height').toPixels('y');
 				if (width == 0 || height == 0) return;
-			
+
 				ctx.save();
 				if (isSvg) {
 					ctx.drawSvg(this.img, x, y, width, height);
@@ -2316,12 +2362,12 @@
 									height,
 									this.img.height,
 									0,
-									0);	
-					ctx.drawImage(this.img, 0, 0);		
+									0);
+					ctx.drawImage(this.img, 0, 0);
 				}
 				ctx.restore();
 			}
-			
+
 			this.getBoundingBox = function() {
 				var x = this.attribute('x').toPixels('x');
 				var y = this.attribute('y').toPixels('y');
@@ -2331,12 +2377,12 @@
 			}
 		}
 		svg.Element.image.prototype = new svg.Element.RenderedElementBase;
-		
+
 		// group element
 		svg.Element.g = function(node) {
 			this.base = svg.Element.RenderedElementBase;
 			this.base(node);
-			
+
 			this.getBoundingBox = function() {
 				var bb = new svg.BoundingBox();
 				for (var i=0; i<this.children.length; i++) {
@@ -2356,13 +2402,13 @@
 				// NO RENDER
 			};
 		}
-		svg.Element.symbol.prototype = new svg.Element.RenderedElementBase;		
-			
+		svg.Element.symbol.prototype = new svg.Element.RenderedElementBase;
+
 		// style element
-		svg.Element.style = function(node) { 
+		svg.Element.style = function(node) {
 			this.base = svg.Element.ElementBase;
 			this.base(node);
-			
+
 			// text, or spaces then CDATA
 			var css = ''
 			for (var i=0; i<node.childNodes.length; i++) {
@@ -2389,6 +2435,7 @@
 								}
 							}
 							svg.Styles[cssClass] = props;
+							svg.StylesSpecificity[cssClass] = getSelectorSpecificity(cssClass);
 							if (cssClass == '@font-face') {
 								var fontFamily = props['font-family'].value.replace(/"/g,'');
 								var srcs = props['src'].value.split(',');
@@ -2412,29 +2459,29 @@
 			}
 		}
 		svg.Element.style.prototype = new svg.Element.ElementBase;
-		
-		// use element 
+
+		// use element
 		svg.Element.use = function(node) {
 			this.base = svg.Element.RenderedElementBase;
 			this.base(node);
-			
+
 			this.baseSetContext = this.setContext;
 			this.setContext = function(ctx) {
 				this.baseSetContext(ctx);
 				if (this.attribute('x').hasValue()) ctx.translate(this.attribute('x').toPixels('x'), 0);
 				if (this.attribute('y').hasValue()) ctx.translate(0, this.attribute('y').toPixels('y'));
 			}
-			
+
 			var element = this.getHrefAttribute().getDefinition();
-			
+
 			this.path = function(ctx) {
 				if (element != null) element.path(ctx);
 			}
-			
+
 			this.getBoundingBox = function() {
 				if (element != null) return element.getBoundingBox();
 			}
-			
+
 			this.renderChildren = function(ctx) {
 				if (element != null) {
 					var tempSvg = element;
@@ -2460,19 +2507,19 @@
 			}
 		}
 		svg.Element.use.prototype = new svg.Element.RenderedElementBase;
-		
+
 		// mask element
 		svg.Element.mask = function(node) {
 			this.base = svg.Element.ElementBase;
 			this.base(node);
-						
+
 			this.apply = function(ctx, element) {
-				// render as temp svg	
+				// render as temp svg
 				var x = this.attribute('x').toPixels('x');
 				var y = this.attribute('y').toPixels('y');
 				var width = this.attribute('width').toPixels('x');
 				var height = this.attribute('height').toPixels('y');
-				
+
 				if (width == 0 && height == 0) {
 					var bb = new svg.BoundingBox();
 					for (var i=0; i<this.children.length; i++) {
@@ -2483,17 +2530,17 @@
 					var width = Math.floor(bb.width());
 					var	height = Math.floor(bb.height());
 				}
-				
+
 				// temporarily remove mask to avoid recursion
 				var mask = element.attribute('mask').value;
 				element.attribute('mask').value = '';
-				
+
 					var cMask = document.createElement('canvas');
 					cMask.width = x + width;
 					cMask.height = y + height;
 					var maskCtx = cMask.getContext('2d');
 					this.renderChildren(maskCtx);
-				
+
 					var c = document.createElement('canvas');
 					c.width = x + width;
 					c.height = y + height;
@@ -2502,38 +2549,38 @@
 					tempCtx.globalCompositeOperation = 'destination-in';
 					tempCtx.fillStyle = maskCtx.createPattern(cMask, 'no-repeat');
 					tempCtx.fillRect(0, 0, x + width, y + height);
-					
+
 					ctx.fillStyle = tempCtx.createPattern(c, 'no-repeat');
 					ctx.fillRect(0, 0, x + width, y + height);
-					
+
 				// reassign mask
-				element.attribute('mask').value = mask;	
+				element.attribute('mask').value = mask;
 			}
-			
+
 			this.render = function(ctx) {
 				// NO RENDER
 			}
 		}
 		svg.Element.mask.prototype = new svg.Element.ElementBase;
-		
+
 		// clip element
 		svg.Element.clipPath = function(node) {
 			this.base = svg.Element.ElementBase;
 			this.base(node);
-			
+
 			this.apply = function(ctx) {
 				var oldBeginPath = CanvasRenderingContext2D.prototype.beginPath;
 				CanvasRenderingContext2D.prototype.beginPath = function () { };
-				
+
 				var oldClosePath = CanvasRenderingContext2D.prototype.closePath;
 				CanvasRenderingContext2D.prototype.closePath = function () { };
-			
+
 				oldBeginPath.call(ctx);
 				for (var i=0; i<this.children.length; i++) {
 					var child = this.children[i];
 					if (typeof(child.path) != 'undefined') {
 						var transform = null;
-						if (child.attribute('transform').hasValue()) { 
+						if (child.attribute('transform').hasValue()) {
 							transform = new svg.Transform(child.attribute('transform').value);
 							transform.apply(ctx);
 						}
@@ -2544,11 +2591,11 @@
 				}
 				oldClosePath.call(ctx);
 				ctx.clip();
-				
+
 				CanvasRenderingContext2D.prototype.beginPath = oldBeginPath;
 				CanvasRenderingContext2D.prototype.closePath = oldClosePath;
 			}
-			
+
 			this.render = function(ctx) {
 				// NO RENDER
 			}
@@ -2559,9 +2606,9 @@
 		svg.Element.filter = function(node) {
 			this.base = svg.Element.ElementBase;
 			this.base(node);
-						
+
 			this.apply = function(ctx, element) {
-				// render as temp svg	
+				// render as temp svg
 				var bb = element.getBoundingBox();
 				var x = Math.floor(bb.x1);
 				var y = Math.floor(bb.y1);
@@ -2571,63 +2618,63 @@
 				// temporarily remove filter to avoid recursion
 				var filter = element.style('filter').value;
 				element.style('filter').value = '';
-				
+
 				var px = 0, py = 0;
 				for (var i=0; i<this.children.length; i++) {
 					var efd = this.children[i].extraFilterDistance || 0;
 					px = Math.max(px, efd);
 					py = Math.max(py, efd);
 				}
-				
+
 				var c = document.createElement('canvas');
 				c.width = width + 2*px;
 				c.height = height + 2*py;
 				var tempCtx = c.getContext('2d');
 				tempCtx.translate(-x + px, -y + py);
 				element.render(tempCtx);
-			
+
 				// apply filters
 				for (var i=0; i<this.children.length; i++) {
 					this.children[i].apply(tempCtx, 0, 0, width + 2*px, height + 2*py);
 				}
-				
+
 				// render on me
 				ctx.drawImage(c, 0, 0, width + 2*px, height + 2*py, x - px, y - py, width + 2*px, height + 2*py);
-				
+
 				// reassign filter
-				element.style('filter', true).value = filter;	
+				element.style('filter', true).value = filter;
 			}
-			
+
 			this.render = function(ctx) {
 				// NO RENDER
-			}		
+			}
 		}
 		svg.Element.filter.prototype = new svg.Element.ElementBase;
-		
+
 		svg.Element.feMorphology = function(node) {
 			this.base = svg.Element.ElementBase;
 			this.base(node);
-			
+
 			this.apply = function(ctx, x, y, width, height) {
 				// TODO: implement
 			}
 		}
 		svg.Element.feMorphology.prototype = new svg.Element.ElementBase;
-		
+
 		svg.Element.feComposite = function(node) {
 			this.base = svg.Element.ElementBase;
 			this.base(node);
-			
+
 			this.apply = function(ctx, x, y, width, height) {
 				// TODO: implement
 			}
 		}
 		svg.Element.feComposite.prototype = new svg.Element.ElementBase;
-		
+
 		svg.Element.feColorMatrix = function(node) {
 			this.base = svg.Element.ElementBase;
 			this.base(node);
-			
+
 			var matrix = svg.ToNumberArray(this.attribute('values').value);
 			switch (this.attribute('type').valueOrDefault('matrix')) { // http://www.w3.org/TR/SVG/filters.html#feColorMatrixElement
 				case 'saturate':
@@ -2655,20 +2702,20 @@
 							  0,0,0,0,1];
 					break;
 			}
-			
+
 			function imGet(img, x, y, width, height, rgba) {
 				return img[y*width*4 + x*4 + rgba];
 			}
-			
+
 			function imSet(img, x, y, width, height, rgba, val) {
 				img[y*width*4 + x*4 + rgba] = val;
 			}
-			
+
 			function m(i, v) {
 				var mi = matrix[i];
 				return mi * (mi < 0 ? v - 255 : v);
 			}
-						
+
 			this.apply = function(ctx, x, y, width, height) {
 				// assuming x==0 && y==0 for now
 				var srcData = ctx.getImageData(0, 0, width, height);
@@ -2689,20 +2736,20 @@
 			}
 		}
 		svg.Element.feColorMatrix.prototype = new svg.Element.ElementBase;
-		
+
 		svg.Element.feGaussianBlur = function(node) {
 			this.base = svg.Element.ElementBase;
 			this.base(node);
 
 			this.blurRadius = Math.floor(this.attribute('stdDeviation').numValue());
 			this.extraFilterDistance = this.blurRadius;
-			
+
 			this.apply = function(ctx, x, y, width, height) {
 				if (typeof(stackBlurCanvasRGBA) == 'undefined') {
 					svg.log('ERROR: StackBlur.js must be included for blur to work');
 					return;
 				}
-				
+
 				// StackBlur requires canvas be on document
 				ctx.canvas.id = svg.UniqueId();
 				ctx.canvas.style.display = 'none';
@@ -2712,7 +2759,7 @@
 			}
 		}
 		svg.Element.feGaussianBlur.prototype = new svg.Element.ElementBase;
-		
+
 		// title element, do nothing
 		svg.Element.title = function(node) {
 		}
@@ -2721,15 +2768,15 @@
 		// desc element, do nothing
 		svg.Element.desc = function(node) {
 		}
-		svg.Element.desc.prototype = new svg.Element.ElementBase;		
-		
+		svg.Element.desc.prototype = new svg.Element.ElementBase;
+
 		svg.Element.MISSING = function(node) {
 			svg.log('ERROR: Element \'' + node.nodeName + '\' not yet implemented.');
 		}
 		svg.Element.MISSING.prototype = new svg.Element.ElementBase;
-		
+
 		// element factory
-		svg.CreateElement = function(node) {	
+		svg.CreateElement = function(node) {
 			var className = node.nodeName.replace(/^[^:]+:/,''); // remove namespace
 			className = className.replace(/\-/g,''); // remove dashes
 			var e = null;
@@ -2743,20 +2790,20 @@
 			e.type = node.nodeName;
 			return e;
 		}
-				
+
 		// load from url
 		svg.load = function(ctx, url) {
 			svg.loadXml(ctx, svg.ajax(url));
 		}
-		
+
 		// load from xml
 		svg.loadXml = function(ctx, xml) {
 			svg.loadXmlDoc(ctx, svg.parseXml(xml));
 		}
-		
+
 		svg.loadXmlDoc = function(ctx, dom) {
 			svg.init(ctx);
-			
+
 			var mapXY = function(p) {
 				var e = ctx.canvas;
 				while (e) {
@@ -2768,7 +2815,7 @@
 				if (window.scrollY) p.y += window.scrollY;
 				return p;
 			}
-			
+
 			// bind mouse
 			if (svg.opts['ignoreMouse'] != true) {
 				ctx.canvas.onclick = function(e) {
@@ -2780,16 +2827,16 @@
 					svg.Mouse.onmousemove(p.x, p.y);
 				};
 			}
-		
+
 			var e = svg.CreateElement(dom.documentElement);
 			e.root = true;
-					
+
 			// render loop
 			var isFirstRender = true;
 			var draw = function() {
 				svg.ViewPort.Clear();
 				if (ctx.canvas.parentNode) svg.ViewPort.SetCurrent(ctx.canvas.parentNode.clientWidth, ctx.canvas.parentNode.clientHeight);
-			
+
 				if (svg.opts['ignoreDimensions'] != true) {
 					// set canvas size
 					if (e.style('width').hasValue()) {
@@ -2807,18 +2854,18 @@
 					cWidth = e.style('width').toPixels('x');
 					cHeight = e.style('height').toPixels('y');
 				}
-				svg.ViewPort.SetCurrent(cWidth, cHeight);		
-				
+				svg.ViewPort.SetCurrent(cWidth, cHeight);
+
 				if (svg.opts['offsetX'] != null) e.attribute('x', true).value = svg.opts['offsetX'];
 				if (svg.opts['offsetY'] != null) e.attribute('y', true).value = svg.opts['offsetY'];
 				if (svg.opts['scaleWidth'] != null || svg.opts['scaleHeight'] != null) {
 					var xRatio = null, yRatio = null, viewBox = svg.ToNumberArray(e.attribute('viewBox').value);
-					
+
 					if (svg.opts['scaleWidth'] != null) {
 						if (e.attribute('width').hasValue()) xRatio = e.attribute('width').toPixels('x') / svg.opts['scaleWidth'];
 						else if (!isNaN(viewBox[2])) xRatio = viewBox[2] / svg.opts['scaleWidth'];
 					}
-					
+
 					if (svg.opts['scaleHeight'] != null) {
 						if (e.attribute('height').hasValue()) yRatio = e.attribute('height').toPixels('y') / svg.opts['scaleHeight'];
 						else if (!isNaN(viewBox[3])) yRatio = viewBox[3] / svg.opts['scaleHeight'];
@@ -2826,12 +2873,12 @@
 
 					if (xRatio == null) { xRatio = yRatio; }
 					if (yRatio == null) { yRatio = xRatio; }
-					
+
 					e.attribute('width', true).value = svg.opts['scaleWidth'];
 					e.attribute('height', true).value = svg.opts['scaleHeight'];
 					e.attribute('transform', true).value += ' scale('+(1.0/xRatio)+','+(1.0/yRatio)+')';
 				}
-			
+
 				// clear and render
 				if (svg.opts['ignoreClear'] != true) {
 					ctx.clearRect(0, 0, cWidth, cHeight);
@@ -2840,88 +2887,88 @@
 				if (isFirstRender) {
 					isFirstRender = false;
 					if (typeof(svg.opts['renderCallback']) == 'function') svg.opts['renderCallback'](dom);
-				}			
+				}
 			}
-			
+
 			var waitingForImages = true;
 			if (svg.ImagesLoaded()) {
 				waitingForImages = false;
 				draw();
 			}
-			svg.intervalID = setInterval(function() { 
+			svg.intervalID = setInterval(function() {
 				var needUpdate = false;
-				
+
 				if (waitingForImages && svg.ImagesLoaded()) {
 					waitingForImages = false;
 					needUpdate = true;
 				}
-			
+
 				// need update from mouse events?
 				if (svg.opts['ignoreMouse'] != true) {
 					needUpdate = needUpdate | svg.Mouse.hasEvents();
 				}
-			
+
 				// need update from animations?
 				if (svg.opts['ignoreAnimation'] != true) {
 					for (var i=0; i<svg.Animations.length; i++) {
 						needUpdate = needUpdate | svg.Animations[i].update(1000 / svg.FRAMERATE);
 					}
 				}
-				
+
 				// need update from redraw?
 				if (typeof(svg.opts['forceRedraw']) == 'function') {
 					if (svg.opts['forceRedraw']() == true) needUpdate = true;
 				}
-				
+
 				// render if needed
 				if (needUpdate) {
-					draw();				
+					draw();
 					svg.Mouse.runEvents(); // run and clear our events
 				}
 			}, 1000 / svg.FRAMERATE);
 		}
-		
+
 		svg.stop = function() {
 			if (svg.intervalID) {
 				clearInterval(svg.intervalID);
 			}
 		}
-		
+
 		svg.Mouse = new (function() {
 			this.events = [];
 			this.hasEvents = function() { return this.events.length != 0; }
-		
+
 			this.onclick = function(x, y) {
-				this.events.push({ type: 'onclick', x: x, y: y, 
+				this.events.push({ type: 'onclick', x: x, y: y,
 					run: function(e) { if (e.onclick) e.onclick(); }
 				});
 			}
-			
+
 			this.onmousemove = function(x, y) {
 				this.events.push({ type: 'onmousemove', x: x, y: y,
 					run: function(e) { if (e.onmousemove) e.onmousemove(); }
 				});
-			}			
-			
+			}
+
 			this.eventElements = [];
-			
+
 			this.checkPath = function(element, ctx) {
 				for (var i=0; i<this.events.length; i++) {
 					var e = this.events[i];
 					if (ctx.isPointInPath && ctx.isPointInPath(e.x, e.y)) this.eventElements[i] = element;
 				}
 			}
-			
+
 			this.checkBoundingBox = function(element, bb) {
 				for (var i=0; i<this.events.length; i++) {
 					var e = this.events[i];
 					if (bb.isPointInBox(e.x, e.y)) this.eventElements[i] = element;
-				}			
+				}
 			}
-			
+
 			this.runEvents = function() {
 				svg.ctx.canvas.style.cursor = '';
-				
+
 				for (var i=0; i<this.events.length; i++) {
 					var e = this.events[i];
 					var element = this.eventElements[i];
@@ -2929,28 +2976,28 @@
 						e.run(element);
 						element = element.parent;
 					}
-				}		
-			
+				}
+
 				// done running, clear
-				this.events = []; 
+				this.events = [];
 				this.eventElements = [];
 			}
 		});
-		
+
 		return svg;
 	}
 })();
 
 if (typeof(CanvasRenderingContext2D) != 'undefined') {
 	CanvasRenderingContext2D.prototype.drawSvg = function(s, dx, dy, dw, dh) {
-		canvg(this.canvas, s, { 
-			ignoreMouse: true, 
-			ignoreAnimation: true, 
-			ignoreDimensions: true, 
-			ignoreClear: true, 
-			offsetX: dx, 
-			offsetY: dy, 
-			scaleWidth: dw, 
+		canvg(this.canvas, s, {
+			ignoreMouse: true,
+			ignoreAnimation: true,
+			ignoreDimensions: true,
+			ignoreClear: true,
+			offsetX: dx,
+			offsetY: dy,
+			scaleWidth: dw,
 			scaleHeight: dh
 		});
 	}

--- a/examples/index.htm
+++ b/examples/index.htm
@@ -236,6 +236,7 @@
 				<option value="issue206.svg">Issue #206: blur</option>
 				<option value="issue211.svg">Issue #211: transform</option>
 				<option value="issue212.svg">Issue #212: path shorthand quadratic bezier</option>
+				<option value="issue217.svg">Issue #217: advanced css support</option>
 				<option value="issue227.svg">Issue #227: clip path transform</option>
 				<option value="issue229.svg">Issue #229: text anchor from style</option>
 				<option value="issue231.svg">Issue #231: clip from style</option>

--- a/svgs/issue217.svg
+++ b/svgs/issue217.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1"> 
+  <style type="text/css"><![CDATA[
+      #foo.rect { fill: blue; }
+      rect#bar { stroke-width: 2.5px; }
+      .parent rect { fill: red; }
+      .parent > .child > rect { fill: yellow; }
+      rect:last-child { stroke: #333; stroke-width: 1.5px; }
+  ]]></style>
+  <g class="parent">
+    <rect id="foo" class="rect" x="10" y="10" width="25" height="15" />
+    <g class="child">
+      <rect id="bar" x="40" y="10" width="25" height="15" />
+    </g>
+    <rect x="70" y="10" width="25" height="15" />
+  </g>
+</svg>


### PR DESCRIPTION
(Ported from patch on googlecode)

This adds advanced CSS support using `Element.matches` (or prefixed `Element.matchesSelector`) where available, with [Sizzle](http://sizzlejs.com/) as a fallback for older browsers.

I'm noticing a lot of line-ending noise - maybe the instructions from [this article](https://help.github.com/articles/dealing-with-line-endings/) would help?