### PR TITLE
Treat clip-path as attribute instead of style

### DIFF
--- a/canvg.js
+++ b/canvg.js
@@ -908,8 +908,8 @@
 				}
 				
 				// clip
-				if (this.style('clip-path', false, true).hasValue()) {
-					var clip = this.style('clip-path', false, true).getDefinition();
+				if (this.attribute('clip-path', false, true).hasValue()) {
+					var clip = this.attribute('clip-path', false, true).getDefinition();
 					if (clip != null) clip.apply(ctx);
 				}
 				

--- a/examples/index.htm
+++ b/examples/index.htm
@@ -251,6 +251,7 @@
 				<option value="issue268.svg">Issue #268: tspan dx dy not affecting x y</option>
 				<option value="issue269.svg">Issue #269: opacity in e-notation</option>
 				<option value="issue273.svg">Issue #273: fill freeze animation</option>
+				<option value="issue282.svg">Issue #282: treat clip path as attribute</option>
 				<option value="issue289.svg">Issue #289: multiple clip</option>
 			</select>
 		</td><td>

--- a/svgs/issue282.svg
+++ b/svgs/issue282.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" id="Layer_1" enable-background="new 0 0 612 792" viewBox="0 0 612 792" x="0px" y="0px" width="612px" height="792px" xmlns:xml="http://www.w3.org/XML/1998/namespace" xml:space="preserve" version="1.1">
+  <defs>
+    <clipPath id="clip-mask">
+      <rect x="0" y="0" width="256" height="256"></rect>
+    </clipPath>
+  </defs>
+  <g clip-path="url('#clip-mask')">
+    <g transform="translate(-128 -128)">
+      <rect x="0" y="0" width="1024" height="1024" fill="#f00"></rect>
+    </g>
+  </g>
+</svg>


### PR DESCRIPTION
#282 contains details on the issue this corrects. Treating the clip-path as an attribute instead of a style fixes issues where the clip would get applied multiple times to child elements of an element with clip-path specified.