### PR TITLE
Fix bug in text rendering

### DIFF
--- a/canvg.js
+++ b/canvg.js
@@ -827,7 +827,7 @@
 					var childNode = node.childNodes[i];
 					if (childNode.nodeType == 1) this.addChild(childNode, true); //ELEMENT_NODE
 					if (this.captureTextNodes && (childNode.nodeType == 3 || childNode.nodeType == 4)) {
-						var text = childNode.nodeValue || childNode.text || '';
+						var text = childNode.nodeValue || childNode.text || childNode.textContent || '';
 						if (svg.trim(svg.compressSpaces(text)) != '') {
 							this.addChild(new svg.Element.tspan(childNode), false); // TEXT_NODE
 						}
@@ -2209,7 +2209,7 @@
 			this.base = svg.Element.TextElementBase;
 			this.base(node);
 			
-			this.text = node.nodeValue || node.text || '';
+			this.text = node.nodeValue || node.text || node.textContent || '';
 			this.getText = function() {
 				return this.text;
 			}


### PR DESCRIPTION
I came across a bug in the text rendering where the text just wasn't visible. After some debugging I found out that the accessors seem to have another alternative in Chrome (I tested it in v40.0.2214.94). I hope this is of any help for you, the library has been great apart from this! :)