### PR TITLE
For stop tag without stop-color attribute.

### DIFF
--- a/canvg.js
+++ b/canvg.js
@@ -1794,7 +1794,8 @@
 			if (this.offset < 0) this.offset = 0;
 			if (this.offset > 1) this.offset = 1;
 			
-			var stopColor = this.style('stop-color');
+			var stopColor = this.style('stop-color', true);
+			if (stopColor.value === '') stopColor.value = '#000';
 			if (this.style('stop-opacity').hasValue()) stopColor = stopColor.addOpacity(this.style('stop-opacity'));
 			this.color = stopColor.value;
 		}


### PR DESCRIPTION
Can't process stop tag without stop-color attribute.

Example:
```
<radialGradient id="SVGID_1_" gradientUnits="userSpaceOnUse" cy="85.35" cx="37.075" gradientTransform="matrix(1 0 0 -.3162 0 127.21)" r="31.402">
  <stop stop-opacity=".2471" offset=".0863"/>
  <stop stop-opacity=".102" offset=".8667"/>
  <stop stop-opacity="0" offset="1"/>
</radialGradient>
```
According to http://www.w3.org/TR/SVG/pservers.html#StopColorProperty,
the stop-color's initial value is black.