### PR TITLE
Add `rgb-color` as bower runtime dependency

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -3,5 +3,8 @@
   "version": "1.0.0",
   "main": "canvg.js",
   "keywords": ["javascript", "client", "browser", "svg", "canvas"],
-  "ignore" : ["examples", "svgs"]
+  "ignore" : ["examples", "svgs"],
+  "dependencies": {
+    "rgb-color": "ariutta/rgb-color"
+  }
 }


### PR DESCRIPTION
The original RGB color parser can be found at
http://www.phpied.com/rgb-color-parser-in-javascript/.
The github project `ariutta/rgb-color` is referenced for lack of a
package in the bower registry.