### PR TITLE
Add support of jQuery and Zepto (Sizzle remains)

### DIFF
--- a/canvg.js
+++ b/canvg.js
@@ -99,7 +99,7 @@
 			};
 		}
 
-		if (typeof matchesSelector !== 'undefined') {
+		if (typeof matchesSelector === 'undefined') {
 			matchesSelector = Sizzle.matchesSelector;
 		}
 	}

--- a/canvg.js
+++ b/canvg.js
@@ -89,8 +89,19 @@
 		};
 	} else {
 		// requires Sizzle: https://github.com/jquery/sizzle/wiki/Sizzle-Documentation
-		// without Sizzle, this is a ReferenceError
-		matchesSelector = Sizzle.matchesSelector;
+		// or jQuery: http://jquery.com/download/
+		// or Zepto: http://zeptojs.com/#
+		// without it, this is a ReferenceError
+
+		if (typeof jQuery === 'function' || typeof Zepto === 'function') {
+			matchesSelector = function (node, selector) {
+				return $(node).is(selector);
+			};
+		}
+
+		if (typeof matchesSelector !== 'undefined') {
+			matchesSelector = Sizzle.matchesSelector;
+		}
 	}
 
 	// slightly modified version of https://github.com/keeganstreet/specificity/blob/master/specificity.js


### PR DESCRIPTION
Hi Gabe,
I need these changes for that to make this library compatible not only with Sizzle but also with jQuery or Zepto. So that you wouldn't need to load Sizzle while you have jQuery loaded already. Only lines 92-104 have been modified, other changes are just IDE trash.

Thanks in advance,
Nikos