### PR TITLE
PR: Introduced `scaleBy` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ The third parameter is options:
 * offsetY: int => draws at a y offset
 * scaleWidth: int => scales horizontally to width
 * scaleHeight: int => scales vertically to height
+* scaleBy: number => scales horizontally and vertically by given coefficient. ignored when either scaleWidth or scaleHeight is defined. Is also ignored when SVG doesn't have a width and height defined.
 * renderCallback: function => will call the function after the first render is completed
 * forceRedraw: function => will call the function on every frame, if it returns true, will redraw
 * useCORS: true => will attempt to use CORS on images to not taint canvas

--- a/canvg.js
+++ b/canvg.js
@@ -23,7 +23,7 @@
 	global.canvg = factory( global.RGBColor, global.stackBlur );
 
 }( typeof window !== 'undefined' ? window : this, function ( RGBColor, stackBlur ) {
- 
+
 	// canvg(target, s)
 	// empty parameters: replace all 'svg' elements on page with 'canvas' elements
 	// target: canvas element or the id of a canvas element
@@ -37,6 +37,7 @@
 	//		 offsetY: int => draws at a y offset
 	//		 scaleWidth: int => scales horizontally to width
 	//		 scaleHeight: int => scales vertically to height
+	//		 scaleBy: int => scales horizontally and vertically by given coefficient. ignored when either scaleWidth or scaleHeight is defined. Is also ignored when SVG doesn't have a width and height defined.
 	//		 renderCallback: function => will call the function after the first render is completed
 	//		 forceRedraw: function => will call the function on every frame, if it returns true, will redraw
 	var canvg = function (target, s, opts) {
@@ -848,7 +849,7 @@
 				child.parent = this;
 				if (child.type != 'title') { this.children.push(child);	}
 			}
-			
+
 			this.addStylesFromStyleDefinition = function () {
 				// add styles
 				for (var selector in svg.Styles) {
@@ -877,7 +878,7 @@
 					var attribute = node.attributes[i];
 					this.attributes[attribute.nodeName] = new svg.Property(attribute.nodeName, attribute.value);
 				}
-				
+
 				this.addStylesFromStyleDefinition();
 
 				// add inline styles
@@ -1729,13 +1730,13 @@
 			this.getGradient = function() {
 				// OVERRIDE ME!
 			}
-			
+
 			this.gradientUnits = function () {
 				return this.attribute('gradientUnits').valueOrDefault('objectBoundingBox');
 			}
-			
+
 			this.attributesToInherit = ['gradientUnits'];
-			
+
 			this.inheritStopContainer = function (stopsContainer) {
 				for (var i=0; i<this.attributesToInherit.length; i++) {
 					var attributeToInherit = this.attributesToInherit[i];
@@ -1805,7 +1806,7 @@
 		svg.Element.linearGradient = function(node) {
 			this.base = svg.Element.GradientBase;
 			this.base(node);
-			
+
 			this.attributesToInherit.push('x1');
 			this.attributesToInherit.push('y1');
 			this.attributesToInherit.push('x2');
@@ -1847,7 +1848,7 @@
 		svg.Element.radialGradient = function(node) {
 			this.base = svg.Element.GradientBase;
 			this.base(node);
-			
+
 			this.attributesToInherit.push('cx');
 			this.attributesToInherit.push('cy');
 			this.attributesToInherit.push('r');
@@ -2903,6 +2904,13 @@
 				svg.ViewPort.Clear();
 				if (ctx.canvas.parentNode) svg.ViewPort.SetCurrent(ctx.canvas.parentNode.clientWidth, ctx.canvas.parentNode.clientHeight);
 
+				if(svg.opts['scaleBy'] != null){
+					if(e.style('width').hasValue())
+						e.style('width').value = e.style('width').toPixels('x') * svg.opts['scaleBy'];
+					if(e.style('height').hasValue())
+						e.style('height').value = e.style('height').toPixels('y') * svg.opts['scaleBy'];
+				}
+
 				if (svg.opts['ignoreDimensions'] != true) {
 					// set canvas size
 					if (e.style('width').hasValue()) {
@@ -2943,6 +2951,15 @@
 					e.attribute('width', true).value = svg.opts['scaleWidth'];
 					e.attribute('height', true).value = svg.opts['scaleHeight'];
 					e.style('transform', true, true).value += ' scale('+(1.0/xRatio)+','+(1.0/yRatio)+')';
+				}
+				else if(svg.opts['scaleBy'] != null){
+					var scaleBy = svg.opts['scaleBy'];
+
+					if (e.attribute('width').hasValue())
+						e.attribute('width', true).value = e.attribute('width').toPixels('x') / svg.opts['scaleBy'];
+
+					if (e.attribute('height').hasValue())
+						e.attribute('height', true).value = e.attribute('height').toPixels('y') / svg.opts['scaleBy'];
 				}
 
 				// clear and render

--- a/canvg.js
+++ b/canvg.js
@@ -37,7 +37,7 @@
 	//		 offsetY: int => draws at a y offset
 	//		 scaleWidth: int => scales horizontally to width
 	//		 scaleHeight: int => scales vertically to height
-	//		 scaleBy: int => scales horizontally and vertically by given coefficient. ignored when either scaleWidth or scaleHeight is defined. Is also ignored when SVG doesn't have a width and height defined.
+	//		 scaleBy: number => scales horizontally and vertically by given coefficient. ignored when either scaleWidth or scaleHeight is defined. Is also ignored when SVG doesn't have a width and height defined.
 	//		 renderCallback: function => will call the function after the first render is completed
 	//		 forceRedraw: function => will call the function on every frame, if it returns true, will redraw
 	var canvg = function (target, s, opts) {


### PR DESCRIPTION
I wanted to scale my svg on canvas programmatically without quality loss.

`scaleX` and `scaleY` is good already, but I couldn't find a way to get the SVG dimensions.

So, I introduced `scaleBy` option with this PR. Pass 2, and the content will be scaled by 2.
I also integrated it with `ignoreDimensions`. That means, when it is not passed (dimensions of canvas to be set automatically), canvas will be also scaled.

