### PR TITLE
Add safe module name to avoid RequireJS errors

### DIFF
--- a/canvg.js
+++ b/canvg.js
@@ -12,7 +12,7 @@
 
 	// export as AMD...
 	if ( typeof define !== 'undefined' && define.amd ) {
-		define("canvgModule", [ 'rgbcolor', 'stackblur' ], factory );
+		define('canvgModule', [ 'rgbcolor', 'stackblur' ], factory );
 	}
 
 	// ...or as browserify

--- a/canvg.js
+++ b/canvg.js
@@ -12,7 +12,7 @@
 
 	// export as AMD...
 	if ( typeof define !== 'undefined' && define.amd ) {
-		define([ 'rgbcolor', 'stackblur' ], factory );
+		define("canvgModule", [ 'rgbcolor', 'stackblur' ], factory );
 	}
 
 	// ...or as browserify


### PR DESCRIPTION
If a safe module name is not defined for requireJS, it will throw a "Mismatched anonymous define() modules..." error in the browser. I just made up a very generic-sounding module name, welcoming suggestions!