### PR TITLE
Microsoft Edge Fix

### DIFF
--- a/canvg.js
+++ b/canvg.js
@@ -875,7 +875,7 @@
 				// add attributes
 				for (var i=0; i<node.attributes.length; i++) {
 					var attribute = node.attributes[i];
-					this.attributes[attribute.nodeName] = new svg.Property(attribute.nodeName, attribute.value);
+					this.attributes[attribute.nodeName.toLowerCase()] = new svg.Property(attribute.nodeName, attribute.value);
 				}
 				
 				this.addStylesFromStyleDefinition();


### PR DESCRIPTION
Please see issue #416

This fix does not solve all the issues in Edge browser, there are still a lot of examples that work incorrectly. But it solves the issue I was running into of having canvg seemingly ignore fills and just render everything black.

After a lot of digging around and debugging in MS Edge, I found that the reason everything is being rendered in black is because Edge uses an uppercase name for fill styles, which meant that fill was never being found as a style. I just modified the line which builds the attributes hash and made it lowercase the attribute name. This has fixed my issues, and hopefully doing this won't have a knock on effect elsewhere (I do not know the library well enough to make a good judgement on this).